### PR TITLE
Diffs and attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 *.so
 /Makefile.dep
+.vscode

--- a/slack-json.c
+++ b/slack-json.c
@@ -3,14 +3,17 @@
 #include "slack-json.h"
 
 json_value *json_get_prop(json_value *val, const char *index) {
-   if (!val || val->type != json_object)
-      return NULL;
+	if (!val || val->type != json_object) {
+		return NULL;
+	}
 
-   for (unsigned int i = 0; i < val->u.object.length; ++ i)
-      if (!strcmp (val->u.object.values [i].name, index))
-         return val->u.object.values[i].value;
+	for (unsigned int i = 0; i < val->u.object.length; ++ i) {
+		if (!strcmp (val->u.object.values[i].name, index)) {
+			return val->u.object.values[i].value;
+		}
+	}
 
-   return NULL;
+	return NULL;
 }
 
 GString *append_json_string(GString *str, const char *s) {

--- a/slack-json.h
+++ b/slack-json.h
@@ -18,6 +18,7 @@
 	json_get_val(JSON, boolean, DEF)
 
 json_value *json_get_prop(json_value *val, const char *prop) __attribute__((pure));
+json_value *json_get_prop_array(json_value *val, const char *prop) __attribute__((pure));
 
 #define json_get_prop_type(JSON, PROP, TYPE) \
 	json_get_type(json_get_prop(JSON, PROP), TYPE)

--- a/slack-message.c
+++ b/slack-message.c
@@ -301,6 +301,13 @@ gchar *slack_json_to_html(SlackAccount *sa, json_value *json, const char *subtyp
 				"<font color=\"#717274\"<i>(Deleted message: \"%s\")</i></font>", 
 				slack_message_to_html(sa, previous_message_text, subtype, flags)
 			);
+		} else {
+			s = json_get_prop_strptr(json, "text");
+			g_string_append_printf(
+				html,
+				"%s",
+				slack_message_to_html(sa, s, subtype, flags)
+			);
 		}
 	// assume this is just a text message.
 	} else {
@@ -444,7 +451,7 @@ gchar *slack_attachment_to_html(SlackAccount *sa, json_value *attachment, Purple
 			"%s"
 
 			// top border
-			"<br />%s"
+			"%s%s"
 			"<br />"
 
 			// service name and author name
@@ -471,10 +478,11 @@ gchar *slack_attachment_to_html(SlackAccount *sa, json_value *attachment, Purple
 		"</font>",
 
 		// pretext
-		pretext ? pretext : "",
+		pretext ? slack_message_to_html(sa, pretext, "attachment", flags) : "",
 		pretext ? "<br /><br />" : "",
 
 		// top border
+		!pretext ? "<br />" : "",
 		border->str,
 
 		// service name and author name

--- a/slack-message.h
+++ b/slack-message.h
@@ -6,6 +6,7 @@
 #include "slack-object.h"
 
 gchar *slack_html_to_message(SlackAccount *sa, const char *s, PurpleMessageFlags flags);
+void add_slack_attachments_to_buffer(GString *buffer, SlackAccount *sa, json_value *attachments, PurpleMessageFlags *flags);
 gchar *slack_json_to_html(SlackAccount *sa, json_value *json, const char *subtype, PurpleMessageFlags *flags);
 gchar *slack_message_to_html(SlackAccount *sa, gchar *s, const char *subtype, PurpleMessageFlags *flags);
 gchar *slack_attachment_to_html(SlackAccount *sa, json_value *attachment, PurpleMessageFlags *flags);

--- a/slack-message.h
+++ b/slack-message.h
@@ -6,7 +6,11 @@
 #include "slack-object.h"
 
 gchar *slack_html_to_message(SlackAccount *sa, const char *s, PurpleMessageFlags flags);
+gchar *slack_json_to_html(SlackAccount *sa, json_value *json, const char *subtype, PurpleMessageFlags *flags);
 gchar *slack_message_to_html(SlackAccount *sa, gchar *s, const char *subtype, PurpleMessageFlags *flags);
+gchar *slack_attachment_to_html(SlackAccount *sa, json_value *attachment, PurpleMessageFlags *flags);
+gchar *get_color(char *c);
+gchar *link(char *url, char *text, int insertBR);
 SlackObject *slack_conversation_get_channel(SlackAccount *sa, PurpleConversation *conv);
 void slack_get_history(SlackAccount *sa, SlackObject *obj, const char *since, unsigned count);
 void slack_mark_conversation(SlackAccount *sa, PurpleConversation *conv);
@@ -17,5 +21,6 @@ void slack_user_typing(SlackAccount *sa, json_value *json);
 
 /* Purple protocol handlers */
 unsigned int slack_send_typing(PurpleConnection *gc, const char *who, PurpleTypingState state);
+void debug(char *s);
 
 #endif // _PURPLE_SLACK_MESSAGE_H


### PR DESCRIPTION
- Shows when someone edited a message that was already in channel previously.
- Attachments now show up.

The testing of attachments was done by posting links from a variety of sources (from https://www.thestar.com/, https://twitter.com/, etc). 

Note that sometimes the summary text inside  attachments can be rather large (e.g. https://techcrunch.com/2018/01/02/apple-buys-app-development-service-buddybuild/ ).  The official Slack client will truncate the text at x-characters and have a "Read More" link so the user can read the rest of the text.  I wasn't sure what theright thing to do for the plugin, so I implemented both the truncated version as well as the "just dump all the text naively" version (the latter of which is what is uncommented .. I am leaving the truncatedversion commented in in case it is decided that this is the right thing to do.