### PR TITLE
don't return a status line if no status is set

### DIFF
--- a/slack-user.c
+++ b/slack-user.c
@@ -69,6 +69,10 @@ SlackUser *slack_user_update(SlackAccount *sa, json_value *json) {
 	if (profile) {
 		g_free(user->status);
 		user->status = g_strdup(json_get_prop_strptr(profile, "status_text") ?: json_get_prop_strptr(profile, "current_status"));
+		if(strlen(user->status) == 0) {
+			g_free(user->status);
+			user->status = NULL;
+		}
 
 		if (user == sa->self)
 			purple_account_set_user_info(sa->account, sa->self->status);
@@ -135,7 +139,7 @@ char *slack_status_text(PurpleBuddy *buddy) {
 	SlackObject *obj = slack_blist_node_get_obj(PURPLE_BLIST_NODE(buddy), &sa);
 	g_return_val_if_fail(SLACK_IS_USER(obj), NULL);
 	SlackUser *user = (SlackUser*)obj;
-	return user ? g_strdup(user->status) : NULL;
+	return user && user->status ? g_strdup(user->status) : NULL;
 }
 
 static void users_info_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {


### PR DESCRIPTION
This gets rid of whitespace in the interface that is not there for other
protocols when no status is set.