### PR TITLE
fix an issue with empty message on threaded replies

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -370,6 +370,10 @@ static void handle_message(SlackAccount *sa, SlackObject *obj, json_value *json,
 		}
 		g_string_append(html, ")");
 	}
+	else if (!g_strcmp0(subtype, "message_replied")) {
+		g_string_free(html, TRUE);
+		return;
+	}
 	else
 		slack_json_to_html(html, sa, message, &flags);
 


### PR DESCRIPTION
I'm very unsure if this is how the fix should actually look, after parsing this and calling slack_json_to_html() on the message the html is empty. Just ignoring the subtype gets rid of the message, but there is information there that might have value for future things..

these come in as a message with the subtype "message_replied" ignoring
these and returning early gets rid of the messages

