### PR TITLE
implement avatar fetching for buddies

### DIFF
--- a/slack-im.c
+++ b/slack-im.c
@@ -94,6 +94,8 @@ gboolean slack_im_set(SlackAccount *sa, json_value *json, const json_value *open
 		}
 	}
 
+	slack_update_avatar(sa, user);
+
 	purple_debug_misc("slack", "im %s: %s\n", user->im, user->object.id);
 	return changed;
 }

--- a/slack-user.c
+++ b/slack-user.c
@@ -259,7 +259,9 @@ static void avatar_cb(G_GNUC_UNUSED PurpleUtilFetchUrlData *fetch, gpointer data
 }
 
 void slack_update_avatar(SlackAccount *sa, SlackUser *user) {
-	if(user->object.buddy && user->avatar_hash && user->avatar_url) {
+	if(purple_account_get_bool(sa->account, "enable_avatar_download", FALSE) &&
+			user->object.buddy && user->avatar_hash && user->avatar_url) {
+
 		const char *checksum = purple_buddy_icons_get_checksum_for_user(user_buddy(user));
 		if(checksum && strcmp(checksum, user->avatar_hash) == 0) {
 			purple_debug_misc("slack", "avatar checksum for %s is the same, skipping\n", user->object.name);

--- a/slack-user.h
+++ b/slack-user.h
@@ -10,6 +10,8 @@ struct _SlackUser {
 	SlackObject object;
 
 	char *status;
+	char *avatar_hash;
+	char *avatar_url;
 
 	/* when there is an open IM channel: */
 	slack_object_id im; /* in ims */
@@ -35,5 +37,7 @@ void slack_presence_change(SlackAccount *sa, json_value *json);
 void slack_set_info(PurpleConnection *gc, const char *info);
 char *slack_status_text(PurpleBuddy *buddy);
 void slack_get_info(PurpleConnection *gc, const char *who);
+
+void slack_update_avatar(SlackAccount *sa, SlackUser *user);
 
 #endif // _PURPLE_SLACK_USER_H

--- a/slack-user.h
+++ b/slack-user.h
@@ -39,5 +39,6 @@ char *slack_status_text(PurpleBuddy *buddy);
 void slack_get_info(PurpleConnection *gc, const char *who);
 
 void slack_update_avatar(SlackAccount *sa, SlackUser *user);
+void slack_start_avatar_queue(SlackAccount *sa);
 
 #endif // _PURPLE_SLACK_USER_H

--- a/slack.c
+++ b/slack.c
@@ -133,6 +133,8 @@ static void slack_login(PurpleAccount *account) {
 	sa->channel_names = g_hash_table_new_full(g_str_hash,      g_str_equal,           NULL, NULL);
 	sa->channel_cids = g_hash_table_new_full(g_direct_hash,    g_direct_equal,        NULL, NULL);
 
+	sa->avatar_queue = g_queue_new();
+
 	sa->buddies = g_hash_table_new_full(/* slack_object_id_hash, slack_object_id_equal, */ g_str_hash, g_str_equal, NULL, NULL);
 
 	sa->mark_list = MARK_LIST_END;
@@ -169,6 +171,7 @@ void slack_login_step(SlackAccount *sa) {
 		case 5:
 			slack_presence_sub(sa);
 			purple_connection_set_state(sa->gc, PURPLE_CONNECTED);
+			slack_start_avatar_queue(sa);
 	}
 #undef MSG
 }
@@ -200,6 +203,9 @@ static void slack_close(PurpleConnection *gc) {
 	g_hash_table_destroy(sa->ims);
 	g_hash_table_destroy(sa->user_names);
 	g_hash_table_destroy(sa->users);
+
+	g_queue_free_full(sa->avatar_queue, g_object_unref);
+
 	g_free(sa->team.id);
 	g_free(sa->team.name);
 	g_free(sa->team.domain);

--- a/slack.c
+++ b/slack.c
@@ -341,6 +341,9 @@ static void init_plugin(G_GNUC_UNUSED PurplePlugin *plugin)
 		purple_account_option_bool_new("Retrieve unread history on open", "get_history", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_bool_new("Download user avatars", "enable_avatar_download", FALSE));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_string_new("Prepend attachment lines with this string", "attachment_prefix", "▎ "));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,

--- a/slack.h
+++ b/slack.h
@@ -46,6 +46,8 @@ typedef struct _SlackAccount {
 
 	guint mark_timer;
 	SlackObject *mark_list;
+
+	GQueue *avatar_queue; /* Queue for avatar downloads */
 } SlackAccount;
 
 void slack_login_step(SlackAccount *sa);


### PR DESCRIPTION
this adds fields in the SlackUser for avatar_hash and avatar_url that
are populated while fetching the users list, after the buddy is created
in slack_im_set() we make a call to a new function slack_avatar_update()
to fetch the avatar. Letting this happen after we actually have the
PurpleBuddy allows caching and not downloading avatars for users that
are not on our list.