### PR TITLE
mark a threaded message as belonging to a thread

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -371,6 +371,11 @@ static void handle_message(SlackAccount *sa, SlackObject *obj, json_value *json,
 		}
 		g_string_append(html, ")");
 	}
+	else if (!g_strcmp0(subtype, "message_replied")) {
+		message = json_get_prop(json, "message");
+		g_string_append(html, "<font color=\"#717274\"><i>[thread]</i></font> ");
+		slack_json_to_html(html, sa, message, &flags);
+	}
 	else
 		slack_json_to_html(html, sa, message, &flags);
 


### PR DESCRIPTION
there might be more useful things to do with this, this only marks it in
the UI as being a threaded reply