### PR TITLE
fix typo on RTM message user_changed->user_change

### DIFF
--- a/slack-rtm.c
+++ b/slack-rtm.c
@@ -40,7 +40,7 @@ static void rtm_msg(SlackAccount *sa, const char *type, json_value *json) {
 	else if (!strcmp(type, "member_left_channel")) {
 		slack_member_joined_channel(sa, json, FALSE);
 	}
-	else if (!strcmp(type, "user_changed") ||
+	else if (!strcmp(type, "user_change") ||
 		 !strcmp(type, "team_join")) {
 		slack_user_changed(sa, json);
 	}


### PR DESCRIPTION
ref: https://api.slack.com/events/user_change