### PR TITLE
Fix for odd display of self-sent messages

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -387,7 +387,11 @@ static void handle_message(SlackAccount *sa, SlackObject *obj, json_value *json,
 		user = sa->self;
 #if PURPLE_VERSION_CHECK(2,12,0)
 		flags |= PURPLE_MESSAGE_REMOTE_SEND;
+#else
+		flags |= 0x10000;
 #endif
+		flags |= PURPLE_MESSAGE_SEND;
+		flags &= ~PURPLE_MESSAGE_RECV;
 	}
 	/* for bots providing different display name */
 	const char *username = json_get_prop_strptr(message, "username");


### PR DESCRIPTION
Messages sent from other clients in one-to-one channels display oddly in Pidgin with a red username instead of a blue one.  This PR fixes up the colour to be more consistent with self-sent messages from other protocols.

(It also fixes the display of self-sent messages on bitlbee which relies on the _SEND flag)