### PR TITLE
Implement automatic history retrieval for unread IMs upon login.

### DIFF
--- a/slack-conversation.h
+++ b/slack-conversation.h
@@ -65,4 +65,9 @@ void slack_get_history_unread(SlackAccount *sa, SlackObject *conv, json_value *j
  */
 void slack_get_conversation_unread(SlackAccount *sa, SlackObject *conv);
 
+/**
+ * Query for unread messages for private chats, and fetch them
+ */
+void slack_unread_messages_load(SlackAccount *sa);
+
 #endif // _PURPLE_SLACK_CONVERSATION_H

--- a/slack.c
+++ b/slack.c
@@ -242,6 +242,11 @@ static void slack_close(PurpleConnection *gc) {
 	if (!sa)
 		return;
 
+	if (sa->fetch_unread_timer) {
+		purple_timeout_remove(sa->fetch_unread_timer);
+		sa->fetch_unread_timer = 0;
+	}
+
 	if (sa->mark_timer) {
 		/* really should send final marks if we can... */
 		purple_timeout_remove(sa->mark_timer);
@@ -260,6 +265,9 @@ static void slack_close(PurpleConnection *gc) {
 	g_hash_table_destroy(sa->rtm_call);
 
 	slack_api_disconnect(sa);
+
+	if (sa->fetch_unread_queue)
+		g_queue_free_full(sa->fetch_unread_queue, &g_free);
 
 	if (sa->roomlist)
 		purple_roomlist_unref(sa->roomlist);

--- a/slack.c
+++ b/slack.c
@@ -230,6 +230,11 @@ void slack_login_step(SlackAccount *sa) {
 			slack_conversations_load(sa);
 			break;
 		case 5:
+			MSG("Loading unread messages");
+			slack_unread_messages_load(sa);
+			break;
+		case 6:
+			MSG("Connected");
 			slack_presence_sub(sa);
 			purple_connection_set_state(sa->gc, PURPLE_CONNECTED);
 	}
@@ -241,11 +246,6 @@ static void slack_close(PurpleConnection *gc) {
 
 	if (!sa)
 		return;
-
-	if (sa->fetch_unread_timer) {
-		purple_timeout_remove(sa->fetch_unread_timer);
-		sa->fetch_unread_timer = 0;
-	}
 
 	if (sa->mark_timer) {
 		/* really should send final marks if we can... */

--- a/slack.h
+++ b/slack.h
@@ -54,7 +54,6 @@ typedef struct _SlackAccount {
 	gboolean away;
 
 	GQueue *fetch_unread_queue; /* Queue for unread messages we need to fetch. */
-	guint fetch_unread_timer;
 } SlackAccount;
 
 void slack_login_step(SlackAccount *sa);

--- a/slack.h
+++ b/slack.h
@@ -52,6 +52,9 @@ typedef struct _SlackAccount {
 	GQueue *avatar_queue; /* Queue for avatar downloads */
 
 	gboolean away;
+
+	GQueue *fetch_unread_queue; /* Queue for unread messages we need to fetch. */
+	guint fetch_unread_timer;
 } SlackAccount;
 
 void slack_login_step(SlackAccount *sa);


### PR DESCRIPTION
It will automatically open conversation windows for all direct and
multi-party direct messages (IM and MPIM), but not for other
channels. It is assumed that the user will want to join other channels
separately.

There is no documented API for getting unread status of all chats
simultaneously, but for efficiency reasons this is important to avoid
getting throttled. So instead we use the undocumented "users.counts"
API call to query for this. Thanks to EionRobb (GitHub) for finding
this one!

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>