### PR TITLE
Deallocate ping timer whenever RTM is deallocated

### DIFF
--- a/slack-rtm.c
+++ b/slack-rtm.c
@@ -148,6 +148,10 @@ static void rtm_connect_cb(SlackAccount *sa, gpointer data, json_value *json, co
 	}
 
 	if (sa->rtm) {
+		if (sa->ping_timer) {
+			purple_timeout_remove(sa->ping_timer);
+			sa->ping_timer = 0;
+		}
 		purple_websocket_abort(sa->rtm);
 		sa->rtm = NULL;
 	}


### PR DESCRIPTION
Over the course of working on #99, I've stumbled into a situation where an old, still allocated `sa->ping_timer` was using a deallocated `sa->rtm` in `slack-rtm.c:rtm_connect_cb`, leading to a crash.