### PR TITLE
Implement the authentication flow that the mobile clients use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 C_SRCS = slack.c \
+	 slack-auth.c \
 	 slack-cmd.c \
 	 slack-message.c \
 	 slack-conversation.c \

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Here's how slack concepts are mapped to purple:
 
 1. Install libpurple (pidgin, finch, etc.), including necessary development components on binary distros (`libpurple-devel`, `libpurple-dev`, etc.)
 1. Run `sudo make install` or `make install-user`
+
+### Authentication
+
+To login enter your email address as the `username` and
+`${WORKSPACE}.slack.com` as the `host`.  You can also optionally enter your
+password and have it saved.
+
+### Legacy Authentication
+
+Earlier versions of this plugin used Slack's legacy tokens for authentication.
+This feature is still supported, but as Slack will be stopping the creation
+of legacy tokens on May 5th 2020, it is highly advised that you migrate to the
+username/password authentication from above.
+
 1. [Issue a Slack API token](https://api.slack.com/custom-integrations/legacy-tokens) for yourself
 1. Add your slack account to your libpurple program and enter this token under (Advanced) API token (do *not* enter your slack password; username/hostname are optional but can be set to `you@your.slack.com`)
 

--- a/slack-auth.c
+++ b/slack-auth.c
@@ -1,0 +1,86 @@
+#include "slack-auth.h"
+#include "slack-api.h"
+#include "slack-json.h"
+
+#include "util.h"
+
+static void
+slack_auth_login_signin_cb(SlackAccount *sa, gpointer user_data, json_value *json, const char *error) {
+	const char *token = json_get_prop_strptr(json, "token");
+
+	if(error != NULL || token == NULL) {
+		purple_connection_error_reason(
+			purple_account_get_connection(sa->account),
+			PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			error ? error : "No token provided");
+
+		return;
+	}
+
+	/* now that we've signed in, we need to clear the values we overrode for
+	 * authentication and set them to the regular values.
+	 */
+	g_free(sa->token);
+	sa->token = g_strdup(token);
+
+	g_free(sa->api_url);
+	sa->api_url = g_strdup_printf("https://%s.slack.com/api", sa->team.name);
+
+	slack_login_step(sa);
+}
+
+static void
+slack_auth_login_finduser_cb(SlackAccount *sa, gpointer user_data, json_value *json, const char *error) {
+	const char *user_id = json_get_prop_strptr(json, "user_id");
+
+	if(error != NULL || user_id == NULL) {
+		purple_connection_error_reason(
+			purple_account_get_connection(sa->account),
+			PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			error ? error : "User not found");
+
+		return;
+	}
+
+	/* now do the actual login */
+	slack_login_step(sa);
+	slack_api_call(sa, slack_auth_login_signin_cb,
+		NULL, "auth.signin",
+		"user", user_id,
+		"password", purple_account_get_password(sa->account),
+		"team", sa->team.id,
+		NULL);
+}
+
+static void
+slack_auth_login_findteam_cb(SlackAccount *sa, gpointer user_data, json_value *json, const char *error) {
+	const char *team_id = json_get_prop_strptr(json, "team_id");
+
+	if(error != NULL || team_id == NULL) {
+		purple_connection_error_reason(
+			purple_account_get_connection(sa->account),
+			PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			error ? error : "Team not found");
+
+		return;
+	}
+
+	sa->team.id = g_strdup(team_id);
+
+	/* now validate that the user exists and get their ID. */
+	slack_login_step(sa);
+	slack_api_call(sa, slack_auth_login_finduser_cb,
+		NULL, "auth.findUser",
+		"email", sa->email,
+		"team", sa->team.id,
+		NULL);
+}
+
+void
+slack_auth_login(SlackAccount *sa) {
+	/* validate the team and get it's ID */
+	slack_api_call(sa, slack_auth_login_findteam_cb,
+		NULL, "auth.findTeam",
+		"domain", sa->team.name,
+		NULL);
+}

--- a/slack-auth.c
+++ b/slack-auth.c
@@ -17,14 +17,18 @@ slack_auth_login_signin_cb(SlackAccount *sa, gpointer user_data, json_value *jso
 		return;
 	}
 
-	/* now that we've signed in, we need to clear the values we overrode for
-	 * authentication and set them to the regular values.
-	 */
+	/* set the new token in the slack account */
 	g_free(sa->token);
 	sa->token = g_strdup(token);
 
+	/* save the token as the password */
+	purple_account_set_password(sa->account, sa->token);
+
+	/* now that we've signed in, we need to clear the values we overrode for
+	 * authentication and set them to the regular values.
+	 */
 	g_free(sa->api_url);
-	sa->api_url = g_strdup_printf("https://%s.slack.com/api", sa->team.name);
+	sa->api_url = g_strdup_printf("https://%s/api", sa->host);
 
 	slack_login_step(sa);
 }
@@ -81,6 +85,6 @@ slack_auth_login(SlackAccount *sa) {
 	/* validate the team and get it's ID */
 	slack_api_call(sa, slack_auth_login_findteam_cb,
 		NULL, "auth.findTeam",
-		"domain", sa->team.name,
+		"domain", sa->host,
 		NULL);
 }

--- a/slack-auth.h
+++ b/slack-auth.h
@@ -1,0 +1,8 @@
+#ifndef _PURPLE_SLACK_AUTH_H
+#define _PURPLE_SLACK_AUTH_H
+
+#include "slack.h"
+
+void slack_auth_login(SlackAccount *sa);
+
+#endif

--- a/slack.c
+++ b/slack.c
@@ -154,7 +154,6 @@ static void slack_conversation_updated(PurpleConversation *conv, PurpleConvUpdat
 
 static void slack_login(PurpleAccount *account) {
 	PurpleConnection *gc = purple_account_get_connection(account);
-	const gchar *username = NULL;
 	gchar *team;
 
 	static gboolean signals_connected = FALSE;

--- a/slack.h
+++ b/slack.h
@@ -17,6 +17,7 @@ typedef struct _SlackAccount {
 	PurpleAccount *account;
 	PurpleConnection *gc;
 	char *email;
+	char *host;
 	char *api_url; /* e.g., "https://slack.com/api" */
 	char *token; /* url encoded */
 

--- a/slack.h
+++ b/slack.h
@@ -16,6 +16,7 @@
 typedef struct _SlackAccount {
 	PurpleAccount *account;
 	PurpleConnection *gc;
+	char *email;
 	char *api_url; /* e.g., "https://slack.com/api" */
 	char *token; /* url encoded */
 


### PR DESCRIPTION
This uses the undocumented methods/ops (not sure what exactly they are called) `findTeam`, `findUser`, and `signin` to implement that same authentication flow that the mobile clients use.  This means, that anyone can use this plugin now without having to get an API key/token created for them.

The main thing to note is that this returns an `xoxs-` token which is not defined at https://api.slack.com/docs/token-types.  That said, until they update the mobile client this should work just fine.

Things to note in this PR.

1. I piggy backed on the `slack_api_call` function but had to do some hackery to make it work.  That is, setting the token to empty string and reassigning `sa->api_url` to the team URL after authentication.  Now this could be used to detect this plugin in the future, but that could be solved by adding a `slack_api_unauthenicated_call` or something like that that wouldn't send an empty token in the `x-www-form-urlencoded` body.
1. I had to do some nasty stuff with account splits that I've never used very much so I'd very much appreciate if @eionrobb takes a close look at this.
1. I wasn't sure about code styling so I mostly guessed.
1. The token still exists, but it is now populated via the authentication flow.
1. team is just the team name, not `team.slack.com`.

The users splits show the account as `email/team` in the accounts window.
![image](https://user-images.githubusercontent.com/1396385/66700055-13152f00-ecb2-11e9-83a3-a66dbfc49a14.png)

The account options is pretty straight forward.
![image](https://user-images.githubusercontent.com/1396385/66700070-393acf00-ecb2-11e9-9e3d-b34d59fc0154.png)
