### PR TITLE
Improve threading support in slack-libpurple.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ C_SRCS = slack.c \
 	 slack-conversation.c \
 	 slack-channel.c \
 	 slack-im.c \
+	 slack-thread.c \
 	 slack-user.c \
 	 slack-rtm.c \
 	 slack-blist.c \
@@ -40,6 +41,7 @@ CFLAGS = \
     -O2 \
     -Wall \
     -D_DEFAULT_SOURCE=1 \
+    -D_XOPEN_SOURCE=1 \
     -std=c99 \
 	-I$(PIDGIN_TREE_TOP)/libpurple \
 	-I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include
@@ -61,6 +63,7 @@ CFLAGS = \
     -Wno-error=strict-aliasing \
     -fPIC \
     -D_DEFAULT_SOURCE=1 \
+    -D_XOPEN_SOURCE=1 \
     -std=c99 \
     $(shell pkg-config --cflags $(PKGS)) \
     $(LOCAL_CFLAGS)

--- a/slack-api.h
+++ b/slack-api.h
@@ -16,4 +16,8 @@ void slack_api_disconnect(SlackAccount *sa);
 
 #define SLACK_PAGINATE_LIMIT	"limit", "500"
 
+// Documented as maximum in API (2020-07-20).
+#define SLACK_HISTORY_LIMIT_NUM 1000
+#define SLACK_HISTORY_LIMIT "limit", "1000"
+
 #endif

--- a/slack-blist.c
+++ b/slack-blist.c
@@ -101,7 +101,7 @@ static void get_history_cb(PurpleBlistNode *buddy, PurpleRequestFields *fields) 
 
 	int count = purple_request_fields_get_integer(fields, "count");
 	if (count > 0)
-		slack_get_history(sa, obj, NULL, count, NULL);
+		slack_get_history(sa, obj, NULL, count, NULL, FALSE);
 	else
 		slack_get_conversation_unread(sa, obj);
 }

--- a/slack-channel.c
+++ b/slack-channel.c
@@ -290,7 +290,7 @@ static void send_chat_cb(SlackAccount *sa, gpointer data, json_value *json, cons
 	send->chan->object.last_sent = g_strdup(tss);
 
 	/* if we've already received this sent message, don't re-display it (#79) */
-	if (slack_ts_cmp(tss, send->chan->object.last_mesg) != 0) {
+	if (slack_ts_cmp(tss, send->chan->object.last_mesg) > 0) {
 		GString *html = g_string_new(NULL);
 		slack_json_to_html(html, sa, json, &send->flags);
 		time_t mt = slack_parse_time(ts);

--- a/slack-channel.h
+++ b/slack-channel.h
@@ -4,6 +4,7 @@
 #include "json.h"
 #include "slack-object.h"
 #include "slack.h"
+#include "slack-thread.h"
 
 typedef enum _SlackChannelType {
 	SLACK_CHANNEL_UNKNOWN = -1, /* no (new) information about type */
@@ -20,6 +21,8 @@ struct _SlackChannel {
 
 	SlackChannelType type;
 	int cid; /* purple chat id, in channel_cids */
+
+	SlackThread *thread;
 };
 
 #define SLACK_TYPE_CHANNEL slack_channel_get_type()

--- a/slack-cmd.c
+++ b/slack-cmd.c
@@ -155,6 +155,21 @@ static PurpleCmdRet cmd_thread(PurpleConversation *conv, const gchar *cmd, gchar
 	return PURPLE_CMD_RET_OK;
 }
 
+static PurpleCmdRet cmd_getthread(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, void *data) {
+	SlackAccount *sa = get_slack_account(conv->account);
+	if (!sa)
+		return PURPLE_CMD_RET_FAILED;
+
+	SlackObject *obj = slack_conversation_get_conversation(sa, conv);
+	if (!obj) {
+		return PURPLE_CMD_RET_FAILED;
+	}
+
+	slack_thread_get_replies(sa, obj, args ? args[0] : "");
+
+	return PURPLE_CMD_RET_OK;
+}
+
 static GSList *commands = NULL;
 
 void slack_cmd_register() {
@@ -204,6 +219,14 @@ void slack_cmd_register() {
 	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
 
 	g_string_free(thread_help, TRUE);
+
+	id = purple_cmd_register("getthread", "s", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY,
+			SLACK_PLUGIN_ID, cmd_getthread, "getthread [thread-timestamp]: Fetch given thread", NULL);
+	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
+
+	id = purple_cmd_register("gt", "s", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY,
+			SLACK_PLUGIN_ID, cmd_getthread, "gt [thread-timestamp]: Fetch given thread", NULL);
+	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
 }
 
 void slack_cmd_unregister() {

--- a/slack-cmd.c
+++ b/slack-cmd.c
@@ -123,27 +123,17 @@ static PurpleCmdRet cmd_thread(PurpleConversation *conv, const gchar *cmd, gchar
 	}
 
 	if (!args || !args[0]) {
-		slack_thread_switch_to_latest(sa, obj);
+		slack_write_message(sa, obj, "Please supply a timestamp and a message.", PURPLE_MESSAGE_SYSTEM);
 		return PURPLE_CMD_RET_OK;
 	}
 
 	gchar *line = g_strdup(args[0]);
 	gchar **split = g_strsplit(line, " ", 2);
 	if (split[0] == NULL)
-		slack_thread_switch_to_latest(sa, obj);
-	else if (split[0][0] == '/') {
-		if (split[0][1] != '\0')
-			slack_write_message(sa, obj, "thread: First argument must be '/' or a valid timestamp", PURPLE_MESSAGE_SYSTEM);
-		else {
-			if (split[1] == NULL) {
-				slack_thread_switch_to_channel(sa, obj);
-			} else {
-				slack_thread_post_to_channel(sa, obj, split[1]);
-			}
-		}
-	} else {
+		slack_write_message(sa, obj, "Please supply a timestamp and a message.", PURPLE_MESSAGE_SYSTEM);
+	else {
 		if (split[1] == NULL) {
-			slack_thread_switch_to_timestamp(sa, obj, split[0]);
+			slack_write_message(sa, obj, "Please supply a message.", PURPLE_MESSAGE_SYSTEM);
 		} else {
 			slack_thread_post_to_timestamp(sa, obj, split[0], split[1]);
 		}
@@ -198,22 +188,15 @@ void slack_cmd_register() {
 	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
 
 	// Make sure the number of %s matches the printfs further down.
-	const char *thread_fmt = "%s [thread-timestamp [message]]:  Post messages in threads.\n"
-			"This command can be used in several ways. One can either switch focus to a thread, causing all messages to be "
-			"posted to that thread, or post single messages to a thread. See these usage examples:\n"
-			"- /%s thread-timestamp:  Switch to thread with given timestamp.\n"
-			"- /%s /:  Switch back to channel.\n"
-			"- /%s:  Switch to the thread of the latest message. Switches to main channel if the latest reply was not threaded.\n"
-			"- /%s thread-timestamp message:  Post single message to the thread with the given timestamp.\n"
-			"- /%s / message:  Post single message to main channel.";
+	const char *thread_fmt = "%s thread-timestamp message:  Post messages in threads.";
 	GString *thread_help = g_string_new(NULL);
 
-	g_string_printf(thread_help, thread_fmt, "th", "th", "th", "th", "th", "th", "th");
+	g_string_printf(thread_help, thread_fmt, "th");
 	id = purple_cmd_register("th", "s", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY |
 			PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS, SLACK_PLUGIN_ID, cmd_thread, thread_help->str, NULL);
 	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
 
-	g_string_printf(thread_help, thread_fmt, "thread", "thread", "thread", "thread", "thread", "thread", "thread");
+	g_string_printf(thread_help, thread_fmt, "thread");
 	id = purple_cmd_register("thread", "s", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY |
 			PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS, SLACK_PLUGIN_ID, cmd_thread, thread_help->str, NULL);
 	commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));

--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -354,7 +354,7 @@ void slack_get_history(SlackAccount *sa, SlackObject *conv, const char *since, u
 void slack_get_history_unread(SlackAccount *sa, SlackObject *conv, json_value *json) {
 	slack_get_history(sa, conv,
 			json_get_prop_strptr(json, "last_read"),
-			json_get_prop_val(json, "unread_count", integer, 0));
+			SLACK_HISTORY_LIMIT_NUM);
 }
 
 static gboolean get_conversation_unread_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {

--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -289,7 +289,7 @@ static gboolean get_history_cb(SlackAccount *sa, gpointer data, json_value *json
 				// messages.
 				continue;
 
-			if (display_threads && !h->thread_ts && thread_ts) {
+			if (display_threads && !h->thread_ts && thread_ts && !g_strcmp0(ts, thread_ts)) {
 				const char *latest_reply = json_get_prop_strptr(msg, "latest_reply");
 				if (!latest_reply || !h->since || slack_ts_cmp(latest_reply, h->since) > 0)
 					add_to_get_history_queue(sa, h->conv, h->since, SLACK_HISTORY_LIMIT_NUM, thread_ts);

--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -263,6 +263,7 @@ static gboolean get_history_cb(SlackAccount *sa, gpointer data, json_value *json
 		/* TODO: pagination has_more? */
 	}
 
+	slack_get_history_free(h);
 	return FALSE;
 }
 

--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -357,6 +357,11 @@ void slack_get_history_unread(SlackAccount *sa, SlackObject *conv, json_value *j
 			SLACK_HISTORY_LIMIT_NUM);
 }
 
+void slack_get_thread_replies(SlackAccount *sa, SlackObject *conv, const char *thread_ts) {
+	if (add_to_get_history_queue(sa, conv, NULL, SLACK_HISTORY_LIMIT_NUM, thread_ts))
+		slack_get_history_next(sa);
+}
+
 static gboolean get_conversation_unread_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
 	SlackObject *conv = data;
 	json = json_get_prop_type(json, "channel", object);

--- a/slack-conversation.h
+++ b/slack-conversation.h
@@ -62,6 +62,12 @@ void slack_get_history(SlackAccount *sa, SlackObject *conv, const char *since, u
 void slack_get_history_unread(SlackAccount *sa, SlackObject *conv, json_value *json);
 
 /**
+ * Retrieve all replies to one thread.
+ * @param thread_ts The "ts" timestamp of the parent message.
+ */
+void slack_get_thread_replies(SlackAccount *sa, SlackObject *conv, const char *thread_ts);
+
+/**
  * Retrieve and display unread history for a conversation
  */
 void slack_get_conversation_unread(SlackAccount *sa, SlackObject *conv);

--- a/slack-conversation.h
+++ b/slack-conversation.h
@@ -52,8 +52,9 @@ void slack_mark_conversation(SlackAccount *sa, PurpleConversation *conv);
  * @param since oldest message to display (NULL for beginning of time)
  * @param count maximum number of messages to display
  * @param thread_ts thread to fetch, or NULL for channel messages
+ * @param force_threads Whether threads should be displayed despite "display_threads" setting.
  */
-void slack_get_history(SlackAccount *sa, SlackObject *conv, const char *since, unsigned count, const char *thread_ts);
+void slack_get_history(SlackAccount *sa, SlackObject *conv, const char *since, unsigned count, const char *thread_ts, gboolean force_threads);
 
 /**
  * Retrieve and display unread history for a conversation

--- a/slack-json.c
+++ b/slack-json.c
@@ -46,6 +46,11 @@ GString *append_json_string(GString *str, const char *s) {
 	return g_string_append_c(str, '"');
 }
 
+time_t slack_parse_time_str(const char *str) {
+	/* "EPOCH.0000ID", atol is sufficient */
+	return atol(str);
+}
+
 time_t slack_parse_time(json_value *val) {
 	if (!val)
 		return 0;
@@ -54,7 +59,6 @@ time_t slack_parse_time(json_value *val) {
 	if (val->type == json_double)
 		return val->u.dbl;
 	if (val->type == json_string)
-		/* "EPOCH.0000ID", atol is sufficient */
-		return atol(val->u.string.ptr);
+		return slack_parse_time_str(val->u.string.ptr);
 	return 0;
 }

--- a/slack-json.h
+++ b/slack-json.h
@@ -37,6 +37,7 @@ json_value *json_get_prop(json_value *val, const char *prop) __attribute__((pure
 /* Add an escaped, quoted json string to a GString */
 GString *append_json_string(GString *str, const char *s);
 
+time_t slack_parse_time_str(const char *str);
 time_t slack_parse_time(json_value *val);
 
 static inline int slack_ts_cmp(const char *a, const char *b) {

--- a/slack-message.c
+++ b/slack-message.c
@@ -478,7 +478,7 @@ void slack_write_message(SlackAccount *sa, SlackObject *obj, const char *html, P
 	}
 }
 
-void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, PurpleMessageFlags flags) {
+void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, PurpleMessageFlags flags, gboolean force_threads) {
 	if (!obj) {
 		purple_debug_warning("slack", "Message to unknown channel %s\n", json_get_prop_strptr(json, "channel"));
 		return;
@@ -490,7 +490,7 @@ void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, 
 	const char *tss = json_get_strptr(ts);
 	const char *subtype = json_get_prop_strptr(json, "subtype");
 
-	if (thread && g_strcmp0(tss, thread) && g_strcmp0(subtype, "thread_broadcast") && !display_threads) {
+	if (thread && g_strcmp0(tss, thread) && g_strcmp0(subtype, "thread_broadcast") && !display_threads && !force_threads) {
 		purple_debug_misc("slack", "Thread replies are turned off, ignoring message.\n");
 		return;
 	}
@@ -528,7 +528,7 @@ void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, 
 			int reply_count = json_get_prop_val(submessage, "reply_count", integer, 0);
 			const char *thread = json_get_prop_strptr(submessage, "thread_ts");
 			if (reply_count == 1 && thread)
-				slack_handle_message(sa, obj, submessage, flags);
+				slack_handle_message(sa, obj, submessage, flags, FALSE);
 		}
 
 		g_string_free(html, TRUE);
@@ -613,7 +613,7 @@ void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, 
 
 static void handle_message(SlackAccount *sa, gpointer data, SlackObject *obj) {
 	json_value *json = data;
-	slack_handle_message(sa, obj, json, PURPLE_MESSAGE_RECV);
+	slack_handle_message(sa, obj, json, PURPLE_MESSAGE_RECV, FALSE);
 	json_value_free(json);
 }
 

--- a/slack-message.c
+++ b/slack-message.c
@@ -415,14 +415,24 @@ void slack_json_to_html(GString *html, SlackAccount *sa, json_value *message, Pu
 	const char *ts = json_get_prop_strptr(message, "ts");
 	const char *thread = json_get_prop_strptr(message, "thread_ts");
 	if (thread) {
+		if (g_strcmp0(ts, thread))
+			g_string_append(html, "⤷ ");
+		else
+			g_string_append(html, "◈ ");
+
 		slack_append_formatted_thread_timestamp(html, thread);
+
 		// If this message is part of a thread, and isn't the parent
 		// message, color it differently to distinguish it from the
 		// channel messages.
 		if (g_strcmp0(ts, thread))
-			g_string_append(html, "⤷  <font color=\"#606060\">");
+			g_string_append(html, ":  <font color=\"#606060\">");
 		else
 			g_string_append(html, ":  ");
+	} else {
+		g_string_append(html, "◇ ");
+		slack_append_formatted_thread_timestamp(html, ts);
+		g_string_append(html, ":  ");
 	}
 
 	slack_message_to_html(html, sa, json_get_prop_strptr(message, "text"), flags, NULL);
@@ -524,8 +534,9 @@ void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, 
 			const char *thread = json_get_prop_strptr(submessage, "thread_ts");
 			if (reply_count == 1 && thread) {
 				GString *msg = g_string_new(NULL);
+				g_string_append(msg, "⤷ ");
 				slack_append_formatted_thread_timestamp(msg, thread);
-				g_string_append(msg, "⤷ Thread opened on message.");
+				g_string_append(msg, "Thread opened on message.");
 				slack_write_message(sa, obj, msg->str, PURPLE_MESSAGE_RECV | PURPLE_MESSAGE_SYSTEM);
 				g_string_free(msg, TRUE);
 			}

--- a/slack-message.c
+++ b/slack-message.c
@@ -381,7 +381,7 @@ void slack_json_to_html(GString *html, SlackAccount *sa, json_value *message, Pu
 
 	if (!g_strcmp0(subtype, "me_message"))
 		g_string_append(html, "/me ");
-	else if (subtype && flags)
+	else if (flags && subtype && strcmp(subtype, "thread_broadcast") != 0)
 		*flags |= PURPLE_MESSAGE_SYSTEM;
 
 	const char *thread = json_get_prop_strptr(message, "thread_ts");

--- a/slack-message.c
+++ b/slack-message.c
@@ -26,24 +26,18 @@ GString *slack_get_thread_color(const char *ts) {
 	// This gives quite a random color, but often with a dominant RGB
 	// component, never white, and deterministic from ts.
 
-	unsigned int seed = slack_parse_time_str(ts);
-	char *dot = strchr(ts, '.');
-	if (dot)
-		seed ^= atol(dot + 1);
-
-	GString *tmp = g_string_sized_new(7);
-
-	unsigned int r = rand_r(&seed);
+	guint r = g_str_hash(ts);
 
 	// Pick random RGB color.
-	unsigned int color = r & 0x7f7f7f;
+	guint color = r & 0x7f7f7f;
 
 	// Pick random RGB high bit by shifting 0x800000 down by 0 (B), 8 (G),
 	// 16 (R), or 24 (0). 0x3000000 are the first bits of 'r' we didn't use
 	// yet.
-	unsigned int pref_color = (0x800000 >> ((r & 0x3000000) >> 21));
+	guint pref_color = (0x800000 >> ((r & 0x3000000) >> 21));
 	color |= pref_color;
 
+	GString *tmp = g_string_sized_new(7);
 	g_string_printf(tmp, "%06x", color);
 
 	return tmp;

--- a/slack-message.c
+++ b/slack-message.c
@@ -411,9 +411,9 @@ void slack_json_to_html(GString *html, SlackAccount *sa, json_value *message, Pu
 	const char *thread = json_get_prop_strptr(message, "thread_ts");
 	if (thread && (display_parent_indicator || g_strcmp0(ts, thread))) {
 		if (g_strcmp0(ts, thread))
-			g_string_append(html, "⤷ ");
+			g_string_append(html, purple_account_get_string(sa->account, "thread_indicator", "⤷ "));
 		else
-			g_string_append(html, "◈ ");
+			g_string_append(html, purple_account_get_string(sa->account, "parent_indicator", "◈ "));
 
 		slack_append_formatted_thread_timestamp(html, thread);
 

--- a/slack-message.h
+++ b/slack-message.h
@@ -9,7 +9,14 @@ gchar *slack_html_to_message(SlackAccount *sa, const char *s, PurpleMessageFlags
 void slack_message_to_html(GString *html, SlackAccount *sa, gchar *s, PurpleMessageFlags *flags, gchar *prepend_newline_str);
 void slack_json_to_html(GString *html, SlackAccount *sa, json_value *json, PurpleMessageFlags *flags);
 /**
- * Display a message
+ * Display a pre-formatted string message
+ *
+ * @param html the HTML formatted message
+ * @param flags additional flags for message
+ */
+void slack_write_message(SlackAccount *sa, SlackObject *obj, const char *html, PurpleMessageFlags flags);
+/**
+ * Display a JSON message
  *
  * @param json the json message object (should contain "subtype" field)
  * @param flags additional flags for message

--- a/slack-message.h
+++ b/slack-message.h
@@ -16,6 +16,15 @@ void slack_json_to_html(GString *html, SlackAccount *sa, json_value *json, Purpl
  */
 void slack_handle_message(SlackAccount *sa, SlackObject *conv, json_value *json, PurpleMessageFlags flags);
 
+/**
+ * Returns a deterministic color for a thread.
+ *
+ * Returned string must be g_string_free'd.
+ *
+ * @param ts "thread_ts" string value from Slack.
+ */
+GString *slack_get_thread_color(const char *ts);
+
 /* RTM event handlers */
 gboolean slack_message(SlackAccount *sa, json_value *json);
 void slack_user_typing(SlackAccount *sa, json_value *json);

--- a/slack-message.h
+++ b/slack-message.h
@@ -32,6 +32,14 @@ void slack_handle_message(SlackAccount *sa, SlackObject *conv, json_value *json,
  */
 GString *slack_get_thread_color(const char *ts);
 
+/**
+ * Appends a formatted ts timestamp to str.
+ *
+ * @param str String to append to. Will be modified.
+ * @param ts Timestamp for format and append.
+ */
+void slack_append_formatted_thread_timestamp(GString *str, const char *ts);
+
 /* RTM event handlers */
 gboolean slack_message(SlackAccount *sa, json_value *json);
 void slack_user_typing(SlackAccount *sa, json_value *json);

--- a/slack-message.h
+++ b/slack-message.h
@@ -20,8 +20,9 @@ void slack_write_message(SlackAccount *sa, SlackObject *obj, const char *html, P
  *
  * @param json the json message object (should contain "subtype" field)
  * @param flags additional flags for message
+ * @param force_threads Whether threads should be displayed despite "display_threads" setting.
  */
-void slack_handle_message(SlackAccount *sa, SlackObject *conv, json_value *json, PurpleMessageFlags flags);
+void slack_handle_message(SlackAccount *sa, SlackObject *conv, json_value *json, PurpleMessageFlags flags, gboolean force_threads);
 
 /**
  * Returns a deterministic color for a thread.

--- a/slack-thread.c
+++ b/slack-thread.c
@@ -1,0 +1,376 @@
+#include "slack-api.h"
+#include "slack-channel.h"
+#include "slack-conversation.h"
+#include "slack-im.h"
+#include "slack-json.h"
+#include "slack-message.h"
+#include "slack-thread.h"
+#include "slack-user.h"
+
+#include <debug.h>
+
+#include <errno.h>
+
+G_DEFINE_TYPE(SlackThread, slack_thread, SLACK_TYPE_OBJECT);
+
+enum ThreadOp {
+	ThreadOpSwitch,
+	ThreadOpPost,
+	ThreadOpSwitchToLatest,
+};
+
+struct thread_op {
+	SlackObject *conv;
+	enum ThreadOp op;
+	char *msg;
+};
+
+static void slack_thread_finalize(GObject *gobj) {
+	SlackThread *thread = SLACK_THREAD(gobj);
+
+	g_free(thread->thread_ts);
+
+	G_OBJECT_CLASS(slack_thread_parent_class)->finalize(gobj);
+}
+
+static void slack_thread_class_init(SlackThreadClass *klass) {
+	GObjectClass *gobj = G_OBJECT_CLASS(klass);
+	gobj->finalize = slack_thread_finalize;
+}
+
+static void slack_thread_init(SlackThread *self) {
+}
+
+static SlackThread *slack_get_thread_from_obj(SlackObject *obj) {
+	if (SLACK_IS_CHANNEL(obj))
+		return ((SlackChannel *)obj)->thread;
+	if (SLACK_IS_USER(obj))
+		return ((SlackUser *)obj)->thread;
+	return NULL;
+}
+
+static gboolean slack_is_slack_ts(const char *str) {
+	gboolean found_prefix = FALSE;
+	gboolean found_dot = FALSE;
+	gboolean found_suffix = FALSE;
+	for (int i = 0; str[i] != '\0'; i++) {
+		if (str[i] >= '0' && str[i] <= '9') {
+			if (found_dot)
+				found_suffix = TRUE;
+			else
+				found_prefix = TRUE;
+			continue;
+		}
+		if (str[i] == '.') {
+			if (found_dot)
+				return FALSE;
+			else
+				found_dot = TRUE;
+		}
+	}
+	return found_prefix && found_dot && found_suffix;
+}
+
+static time_t slack_get_ts_from_time_str(const char *time_str) {
+	struct tm tm;
+	char *result;
+
+	time_t ts = time(NULL);
+	localtime_r(&ts, &tm);
+
+	// Time only.
+	result = strptime(time_str, "%X", &tm);
+	if (result == time_str + strlen(time_str))
+		return mktime(&tm);
+
+	// Date and time.
+	result = strptime(time_str, "%x-%X", &tm);
+	if (result == time_str + strlen(time_str))
+		return mktime(&tm);
+
+	return 0;
+}
+
+static struct thread_op *thread_op_new_switch(SlackObject *conv) {
+	struct thread_op *ret = g_new(struct thread_op, 1);
+	ret->conv = g_object_ref(conv);
+	ret->op = ThreadOpSwitch;
+	ret->msg = NULL;
+	return ret;
+}
+
+static struct thread_op *thread_op_new_post(SlackObject *conv, const char *msg) {
+	struct thread_op *ret = g_new(struct thread_op, 1);
+	ret->conv = g_object_ref(conv);
+	ret->op = ThreadOpPost;
+	ret->msg = g_strdup(msg);
+	return ret;
+}
+
+static void thread_op_free(struct thread_op *op) {
+	if (!op)
+		return;
+
+	g_object_unref(op->conv);
+	g_free(op->msg);
+	g_free(op);
+}
+
+static int slack_thread_send_message(SlackAccount *sa, SlackObject *conv, const char *msg, PurpleMessageFlags flags) {
+	if (SLACK_IS_CHANNEL(conv)) {
+		SlackChannel *chan = (SlackChannel *)conv;
+		slack_chat_send(sa->gc, chan->cid, msg, flags);
+	} else if (SLACK_IS_USER(conv)) {
+		SlackUser *user = (SlackUser *)conv;
+		slack_send_im(sa->gc, user->object.name, msg, flags);
+	} else
+		return -ENOENT;
+
+	return 1;
+}
+
+static void slack_thread_switch(SlackAccount *sa, SlackObject *conv, const char *ts) {
+	SlackThread *th = slack_get_thread_from_obj(conv);
+
+	g_free(th->thread_ts);
+	th->thread_ts = g_strdup(ts);
+
+	GString *color = slack_get_thread_color(ts);
+
+	time_t tmp = slack_parse_time_str(ts);
+	struct tm thread_time;
+	localtime_r(&tmp, &thread_time);
+
+	char time_str[100];
+	strftime(time_str, sizeof(time_str), "%x-%X", &thread_time);
+	GString *msg = g_string_new(NULL);
+	g_string_printf(msg, "Switched conversation thread to <font color=\"#%s\">%s</font> (%s).", color->str, time_str, ts);
+	slack_write_message(sa, conv, msg->str, PURPLE_MESSAGE_SYSTEM);
+
+	g_string_free(msg, TRUE);
+	g_string_free(color, TRUE);
+}
+
+static void slack_thread_post(SlackAccount *sa, SlackObject *conv, const char *ts, const char *msg) {
+	SlackThread *th = slack_get_thread_from_obj(conv);
+
+	if (!msg)
+		return;
+
+	// Temporarily set thread_ts for this one message, and then restore it
+	// afterwards.
+	char *old_thread_ts = th->thread_ts;
+	th->thread_ts = g_strdup(ts);
+
+	int status = slack_thread_send_message(sa, conv, msg, 0);
+	if (status < 0)
+		purple_debug_error("slack", "Not able to send message \"%s\": %s\n", msg, strerror(-status));
+
+	g_free(th->thread_ts);
+	th->thread_ts = old_thread_ts;
+}
+
+static gboolean slack_thread_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
+	struct thread_op *op = data;
+	if (!op)
+		return FALSE;
+
+	SlackObject *conv = op->conv;
+
+	json_value *list = json_get_prop_type(json, "messages", array);
+
+	if (!list || error) {
+		purple_debug_error("slack", "Error querying threads: %s\n", error ?: "missing");
+	}
+
+	if (list->u.array.length <= 0) {
+		slack_write_message(sa, conv, "Thread not found. If the thread start date is not today, make sure you specify the date in the thread timestamp.", PURPLE_MESSAGE_SYSTEM);
+		goto end;
+	} else if (list->u.array.length > 1) {
+		GString *errmsg = g_string_new(NULL);
+		g_string_assign(errmsg, "Thread timestamp is ambiguous. Please use one of the following unambiguous thread IDs:\n");
+		for (unsigned i = 0; i < list->u.array.length; i++) {
+			json_value *entry = list->u.array.values[i];
+			const char *ts = json_get_prop_strptr(entry, "ts");
+			if (ts) {
+				const char *msg = json_get_prop_strptr(entry, "text");
+				GString *color = slack_get_thread_color(ts);
+				g_string_append(errmsg, "<font color=\"#");
+				g_string_append(errmsg, color->str);
+				g_string_append(errmsg, "\">");
+				g_string_append(errmsg, ts);
+				g_string_append(errmsg, "</font> (\"");
+				g_string_append(errmsg, msg ?: "NULL");
+				g_string_append(errmsg, "\")\n");
+
+				g_string_free(color, TRUE);
+			}
+		}
+		slack_write_message(sa, conv, errmsg->str, PURPLE_MESSAGE_SYSTEM);
+		g_string_free(errmsg, TRUE);
+		goto end;
+	}
+
+	json_value *entry = list->u.array.values[0];
+	const char *ts = json_get_prop_strptr(entry, "ts");
+	if (!ts) {
+		purple_debug_misc("slack", "Missing ts value in thread callback\n");
+		goto end;
+	}
+
+	switch (op->op) {
+	case ThreadOpSwitch:
+		slack_thread_switch(sa, conv, ts);
+		break;
+	case ThreadOpPost:
+		slack_thread_post(sa, conv, ts, op->msg);
+		break;
+	default:
+		break;
+	}
+
+end:
+	thread_op_free(op);
+	return FALSE;
+}
+
+static gboolean slack_latest_thread_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
+	struct thread_op *op = data;
+	if (!op)
+		return FALSE;
+
+	SlackObject *conv = op->conv;
+
+	json_value *list = json_get_prop_type(json, "messages", array);
+
+	if (!list || error) {
+		purple_debug_error("slack", "Error querying threads: %s\n", error ?: "missing");
+	}
+
+	gchar *latest_ts = NULL;
+	gchar *latest_thread = NULL;
+	for (int i = 0; i < list->u.array.length; i++) {
+		json_value *entry = list->u.array.values[i];
+		const char *thread_ts = json_get_prop_strptr(entry, "thread_ts");
+		if (thread_ts) {
+			const char *latest_reply = json_get_prop_strptr(entry, "latest_reply");
+			if (latest_reply && (!latest_ts || slack_ts_cmp(latest_reply, latest_ts) > 0)) {
+				g_free(latest_ts);
+				latest_ts = g_strdup(latest_reply);
+				g_free(latest_thread);
+				latest_thread = g_strdup(thread_ts);
+			}
+		} else {
+			const char *ts = json_get_prop_strptr(entry, "ts");
+			if (ts && (!latest_ts || slack_ts_cmp(ts, latest_ts) > 0)) {
+				g_free(latest_ts);
+				latest_ts = g_strdup(ts);
+				g_free(latest_thread);
+				latest_thread = NULL;
+			}
+		}
+	}
+
+	if (latest_thread)
+		slack_thread_switch(sa, conv, latest_thread);
+	else
+		slack_thread_switch_to_channel(sa, conv);
+
+	g_free(latest_ts);
+	g_free(latest_thread);
+
+	return FALSE;
+}
+
+static void slack_thread_call_operation(SlackAccount *sa, SlackObject *obj, struct thread_op *op, time_t ts) {
+	GString *oldest = g_string_new(NULL);
+	g_string_printf(oldest, "%ld.000000", ts);
+	GString *latest = g_string_new(NULL);
+	g_string_printf(latest, "%ld.999999", ts);
+
+	const char *id = slack_conversation_id(obj);
+	slack_api_get(sa, slack_thread_cb, op, "conversations.history", "channel", id, "oldest", oldest->str, "latest", latest->str, NULL);
+
+	g_string_free(oldest, TRUE);
+	g_string_free(latest, TRUE);
+}
+
+void slack_thread_switch_to_channel(SlackAccount *sa, SlackObject *obj) {
+	SlackThread *thread = slack_get_thread_from_obj(obj);
+	if (!thread)
+		return;
+
+	g_free(thread->thread_ts);
+	thread->thread_ts = NULL;
+	slack_write_message(sa, obj, "Switched conversation thread to channel.", PURPLE_MESSAGE_SYSTEM);
+}
+
+void slack_thread_switch_to_timestamp(SlackAccount *sa, SlackObject *obj, const char *timestr) {
+	SlackThread *thread = slack_get_thread_from_obj(obj);
+	if (!thread)
+		return;
+
+	if (slack_is_slack_ts(timestr))
+		slack_thread_switch(sa, obj, timestr);
+	else {
+		time_t ts = slack_get_ts_from_time_str(timestr);
+		if (ts == 0) {
+			slack_write_message(sa, obj, "Could not parse thread timestamp.", PURPLE_MESSAGE_SYSTEM);
+			return;
+		}
+
+		struct thread_op *op = thread_op_new_switch(obj);
+		slack_thread_call_operation(sa, obj, op, ts);
+	}
+}
+
+void slack_thread_switch_to_latest(SlackAccount *sa, SlackObject *obj) {
+	SlackThread *thread = slack_get_thread_from_obj(obj);
+	if (!thread)
+		return;
+
+	const char *id = slack_conversation_id(obj);
+	struct thread_op *op = thread_op_new_switch(obj);
+	slack_api_get(sa, slack_latest_thread_cb, op, "conversations.history", "channel", id, SLACK_HISTORY_LIMIT, NULL);
+}
+
+void slack_thread_post_to_channel(SlackAccount *sa, SlackObject *obj, const char *msg) {
+	SlackThread *th = slack_get_thread_from_obj(obj);
+
+	// Temporarily set thread_ts for this one message, and then restore it
+	// afterwards.
+	char *old_thread_ts = th->thread_ts;
+	th->thread_ts = NULL;
+
+	int status = slack_thread_send_message(sa, obj, msg, 0);
+	if (status < 0)
+		purple_debug_error("slack", "Not able to send message \"%s\": %s\n", msg, strerror(-status));
+
+	th->thread_ts = old_thread_ts;
+
+	if (SLACK_IS_USER(obj))
+		// In IM windows, Pidgin posts the message from self directly
+		// from the input, not the remote socket. But since this message
+		// was sent using a command, it will not show up, so post it
+		// here.
+		slack_write_message(sa, obj, msg, PURPLE_MESSAGE_SEND);
+}
+
+void slack_thread_post_to_timestamp(SlackAccount *sa, SlackObject *obj, const char *timestr, const char *msg) {
+	SlackThread *thread = slack_get_thread_from_obj(obj);
+	if (!thread)
+		return;
+
+	if (slack_is_slack_ts(timestr))
+		slack_thread_post(sa, obj, timestr, msg);
+	else {
+		time_t ts = slack_get_ts_from_time_str(timestr);
+		if (ts == 0) {
+			slack_write_message(sa, obj, "Could not parse thread timestamp.", PURPLE_MESSAGE_SYSTEM);
+			return;
+		}
+
+		struct thread_op *op = thread_op_new_post(obj, msg);
+		slack_thread_call_operation(sa, obj, op, ts);
+	}
+}

--- a/slack-thread.h
+++ b/slack-thread.h
@@ -18,5 +18,6 @@ void slack_thread_switch_to_latest(SlackAccount *sa, SlackObject *obj);
 void slack_thread_post_to_channel(SlackAccount *sa, SlackObject *obj, const char *msg);
 void slack_thread_post_to_timestamp(SlackAccount *sa, SlackObject *obj, const char *timestr, const char *msg);
 void slack_thread_post_to_latest(SlackAccount *sa, SlackObject *obj, const char *msg);
+void slack_thread_get_replies(SlackAccount *sa, SlackObject *obj, const char *timestr);
 
 #endif // _PURPLE_SLACK_THREAD_H

--- a/slack-thread.h
+++ b/slack-thread.h
@@ -1,0 +1,22 @@
+#ifndef _PURPLE_SLACK_THREAD_H
+#define _PURPLE_SLACK_THREAD_H
+
+#include "slack.h"
+
+struct _SlackThread {
+	SlackObject object;
+
+	char *thread_ts; /* Currently selected thread. */
+};
+
+#define SLACK_TYPE_THREAD slack_thread_get_type()
+G_DECLARE_FINAL_TYPE(SlackThread, slack_thread, SLACK, THREAD, SlackObject)
+
+void slack_thread_switch_to_channel(SlackAccount *sa, SlackObject *obj);
+void slack_thread_switch_to_timestamp(SlackAccount *sa, SlackObject *obj, const char *timestr);
+void slack_thread_switch_to_latest(SlackAccount *sa, SlackObject *obj);
+void slack_thread_post_to_channel(SlackAccount *sa, SlackObject *obj, const char *msg);
+void slack_thread_post_to_timestamp(SlackAccount *sa, SlackObject *obj, const char *timestr, const char *msg);
+void slack_thread_post_to_latest(SlackAccount *sa, SlackObject *obj, const char *msg);
+
+#endif // _PURPLE_SLACK_THREAD_H

--- a/slack-user.c
+++ b/slack-user.c
@@ -3,6 +3,7 @@
 #include "slack-json.h"
 #include "slack-api.h"
 #include "slack-blist.h"
+#include "slack-thread.h"
 #include "slack-user.h"
 #include "slack-im.h"
 
@@ -14,6 +15,7 @@ static void slack_user_finalize(GObject *gobj) {
 	g_free(user->status);
 	g_free(user->avatar_hash);
 	g_free(user->avatar_url);
+        g_object_unref(user->thread);
 
 	G_OBJECT_CLASS(slack_user_parent_class)->finalize(gobj);
 }
@@ -24,6 +26,7 @@ static void slack_user_class_init(SlackUserClass *klass) {
 }
 
 static void slack_user_init(SlackUser *self) {
+	self->thread = g_object_new(SLACK_TYPE_THREAD, NULL);
 }
 
 SlackUser *slack_user_set(SlackAccount *sa, const char *sid, const char *name) {

--- a/slack-user.h
+++ b/slack-user.h
@@ -4,6 +4,7 @@
 #include "json.h"
 #include "slack-object.h"
 #include "slack.h"
+#include "slack-thread.h"
 
 /* SlackUser represents both a user object, and an optional im object */
 struct _SlackUser {
@@ -15,6 +16,8 @@ struct _SlackUser {
 
 	/* when there is an open IM channel: */
 	slack_object_id im; /* in ims */
+
+	SlackThread *thread;
 };
 
 #define SLACK_TYPE_USER slack_user_get_type()

--- a/slack.c
+++ b/slack.c
@@ -561,6 +561,9 @@ static void init_plugin(G_GNUC_UNUSED PurplePlugin *plugin)
 		purple_account_option_bool_new("Open chat on channel message", "open_chat", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_bool_new("Display thread replies", "display_threads", TRUE));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_bool_new("Retrieve unread IM (*and conversation) history on connect", "load_history", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,

--- a/slack.c
+++ b/slack.c
@@ -160,9 +160,20 @@ static guint slack_conversation_send_typing(PurpleConversation *conv, PurpleTypi
 	
 	if (!obj)
 		return 0;
+
+	SlackChannel *chan;
+	if (SLACK_IS_CHANNEL(obj))
+		chan = (SlackChannel *)obj;
+	else {
+		purple_debug_error("slack", "Could not convert to channel object. Should not happen.\n");
+		return 0;
+	}
 	
 	GString *channel = append_json_string(g_string_new(NULL), slack_conversation_id(obj));
-	slack_rtm_send(sa, NULL, NULL, "typing", "channel", channel->str, NULL);
+	if (chan->thread->thread_ts)
+		slack_rtm_send(sa, NULL, NULL, "typing", "channel", channel->str, "thread_ts", chan->thread->thread_ts, NULL);
+	else
+		slack_rtm_send(sa, NULL, NULL, "typing", "channel", channel->str, NULL);
 	g_string_free(channel, TRUE);
 	
 	return 3;

--- a/slack.c
+++ b/slack.c
@@ -564,6 +564,9 @@ static void init_plugin(G_GNUC_UNUSED PurplePlugin *plugin)
 		purple_account_option_bool_new("Display thread replies", "display_threads", TRUE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_bool_new("Display parent indicator when thread is opened", "display_parent_indicator", TRUE));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_bool_new("Retrieve unread IM (*and conversation) history on connect", "load_history", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,

--- a/slack.c
+++ b/slack.c
@@ -563,7 +563,13 @@ static void init_plugin(G_GNUC_UNUSED PurplePlugin *plugin)
 		purple_account_option_bool_new("Display thread replies", "display_threads", TRUE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_string_new("Prepend thread replies with this string", "thread_indicator", "⤷ "));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_bool_new("Display parent indicator when thread is opened", "display_parent_indicator", TRUE));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_string_new("Prepend parent messages with this string", "parent_indicator", "◈ "));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_bool_new("Retrieve unread IM (*and conversation) history on connect", "load_history", FALSE));


### PR DESCRIPTION
This PR adds support for three main things:

* Colorizing of threads for easier visual distinction.
* Ability to fetch thread history.
* Ability to post in threads.

This is how the thread posting works, by using the "/thread" chat command ("/th" for short):

> /th [thread-timestamp [message]]:  Post messages in threads.
> This command can be used in several ways. One can either switch focus to a thread, causing all messages to be posted to that thread, or post single messages to a thread. See these usage examples:
> - /th thread-timestamp:  Switch to thread with given timestamp.
> - /th /:  Switch back to channel.
> - /th:  Switch to the thread of the latest message. Switches to main channel if the latest reply was not threaded.
> - /th thread-timestamp message:  Post single message to the thread with the given timestamp.
> - /th / message:  Post single message to main channel.

Each commit gives more details about the implementation.

There are some things that need to be sorted out. Just to be clear: This PR is **not ready for merging**, and there are several issues I'd like to discuss first. However, it serves as a starting point, and it *does* work, so people can start testing it today.

Things to discuss:

* Is the /thread command the right way to go? The only other way I can envision is turning threads into channels, but I think this would be incredibly confusing, and I think personally I would not like this approach.

* There are some serious hacks in place to get it to work. Most notably, AFAIK there is *no* public API for getting thread replies by date if you don't already know the thread parent. This means it's impossible to get history of threads that have received replies, unless the parent is also within the same time range. The hack which is in place now is to unconditonally query the last 1000 messages (the maximum that Slack allows), even when limiting by timestamp, and do timestamp comparisons locally instead. This means that you can get thread history at least for threads whose parent is less than 1000 messages old.

* Due to normal history and thread history being different API, the history fetcher will always display normal history first, and then each thread afterwards, which means they won't be in order. This is solvable, but quite hairy because we have to remember the JSON replies and then sort them, and we don't currently have a JSON deep copy function...

* Again due to different APIs, limiting number of messages by number is not a well defined operation anymore, and if you request 1 message, you can still get hundreds of messages if that one message happened to be the parent of a busy thread. This would likely also be improved if we solved the previous point. The question is whether it is worth it, or if it's better to introduce fetching by date instead, which is often more useful.

* Posting to threads works in both channels and IMs, but in IMs it behaves a bit strangely, and this is mostly due to how Purple works (at least when using Pidgin). When switching to a thread context, and then posting, you will see both a thread-less and then a threaded message. This is because when you are not using a command, Purple posts the message immediately, without letting the plugin control how it should be displayed. Only once the server replies does it get displayed properly. I'm not sure if this is fixable, but since threads are less common in IMs, I'm not rushing to fix it.

* I've tweaked the display of thread timestamps slightly. First of all they include date, if the day is not today. Also, I have eliminated all spaces in them. This is so that they can be used with the thread command using a simple copy and paste. However, I'm not 100% sure that the time format operators I've used (%x and %X) are without whitespace in all locales, and if they're not, the "/thread" command won't work.

* If the chat background is dark instead of white (either because slack-libpurple is used in a terminal client, or if Pidgin is using a dark GTK theme), the thread colors are not well adapted. It should probably be possible to turn them off and/or enable inverted mode.

Let me know what you think!