### PR TITLE
Fix auth when using legacy tokens

### DIFF
--- a/slack-api.c
+++ b/slack-api.c
@@ -79,7 +79,7 @@ static void api_cb(G_GNUC_UNUSED PurpleUtilFetchUrlData *fetch, gpointer data, c
 static gboolean api_retry(gpointer data) {
 	SlackAPICall *call = data;
 	call->fetch = purple_util_fetch_url_request_len_with_account(call->sa->account,
-			call->url, TRUE, NULL, TRUE, NULL, FALSE, 4096*1024,
+			call->url, FALSE, NULL, TRUE, NULL, FALSE, 4096*1024,
 			api_cb, call);
 	return FALSE;
 }

--- a/slack.c
+++ b/slack.c
@@ -209,6 +209,12 @@ static void slack_login(PurpleAccount *account) {
 		 * addresses, so we manually split it here.
 		 */
 		host = g_strstr_len(username, -1, "@");
+		if (host) {
+			gchar *percent = g_strrstr(host, "%");
+			if (percent) {
+				*percent = '\0';
+			}
+		}
 	}
 
 	/* if we had a legacy token and it failed to find a host, try the % as well
@@ -246,7 +252,9 @@ static void slack_login(PurpleAccount *account) {
 		 */
 		sa->email = g_strdup(purple_account_get_username(account));
 		gchar *percent = g_strrstr(sa->email, "%");
-		*percent = '\0';
+		if (percent) {
+			*percent = '\0';
+		}
 	}
 
 	sa->rtm_call = g_hash_table_new_full(g_direct_hash,        g_direct_equal,        NULL, (GDestroyNotify)slack_rtm_cancel);


### PR DESCRIPTION
There was a server-side change to the Slack HTTP servers that they not longer respond correctly to a full url request (eg `GET https://site.slack.com/api/rtm.connect?token=... HTTP/1.1`)

This change turns it back into a regular  `/api/rtm.connect` partial URL (but also needed fixes to strip after the % when using the legacy token, otherwise it tries to use a hostname of `site.slack.com%slack.com`)