### PR TITLE
Fix truncated messages when editing long messages.

### DIFF
--- a/slack-api.c
+++ b/slack-api.c
@@ -17,6 +17,7 @@ PurpleConnectionError slack_api_connection_error(const gchar *error) {
 struct _SlackAPICall {
 	SlackAccount *sa;
 	char *url;
+	char *request;
 	PurpleUtilFetchUrlData *fetch;
 	SlackAPICallback *callback;
 	gpointer data;
@@ -24,11 +25,17 @@ struct _SlackAPICall {
 	SlackAPICall **prev, *next;
 };
 
+typedef struct _SlackUrlAndRequest {
+	GString *url;
+	GString *request;
+} SlackUrlAndRequest;
+
 static void api_error(SlackAPICall *call, const char *error) {
 	if ((*call->prev = call->next))
 		call->next->prev = call->prev;
 	if (call->callback)
 		call->callback(call->sa, call->data, NULL, error);
+	g_free(call->request);
 	g_free(call->url);
 	g_free(call);
 };
@@ -72,6 +79,7 @@ static void api_cb(G_GNUC_UNUSED PurpleUtilFetchUrlData *fetch, gpointer data, c
 
 	if (json)
 		json_value_free(json);
+	g_free(call->request);
 	g_free(call->url);
 	g_free(call);
 }
@@ -79,14 +87,14 @@ static void api_cb(G_GNUC_UNUSED PurpleUtilFetchUrlData *fetch, gpointer data, c
 static gboolean api_retry(gpointer data) {
 	SlackAPICall *call = data;
 	call->fetch = purple_util_fetch_url_request_len_with_account(call->sa->account,
-			call->url, FALSE, NULL, TRUE, NULL, FALSE, 4096*1024,
+			call->url, FALSE, NULL, TRUE, call->request, FALSE, 4096*1024,
 			api_cb, call);
 	return FALSE;
 }
 
-static GString *slack_api_encode_url(SlackAccount *sa, const char *pfx, const char *method, va_list qargs) {
+static GString *slack_api_encode_url(SlackAccount *sa, const char *pfx, const char *endpoint, va_list qargs) {
 	GString *url = g_string_new(NULL);
-	g_string_printf(url, "%s/%s%s?token=%s", sa->api_url, pfx, method, sa->token);
+	g_string_printf(url, "%s/%s%s?token=%s", sa->api_url, pfx, endpoint, sa->token);
 
 	const char *param;
 	while ((param = va_arg(qargs, const char*))) {
@@ -97,33 +105,117 @@ static GString *slack_api_encode_url(SlackAccount *sa, const char *pfx, const ch
 	return url;
 }
 
-static void slack_api_call_url(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, const char *url) {
+static GString *slack_api_escape_quotes(const char *str) {
+	GString *escaped = g_string_new(NULL);
+	for (size_t i = 0; str[i] != '\0'; i++) {
+		switch (str[i]) {
+		case '"':
+			g_string_append(escaped, "\\\"");
+			break;
+		case '\\':
+			g_string_append(escaped, "\\\\");
+			break;
+		default:
+			g_string_append_c(escaped, str[i]);
+			break;
+		}
+	}
+	return escaped;
+}
+
+static SlackUrlAndRequest slack_api_encode_url_and_post_request(SlackAccount *sa, const char *endpoint, va_list qargs) {
+	GString *url = g_string_new(NULL);
+	g_string_printf(url, "%s/%s", sa->api_url, endpoint);
+
+	GString *postdata;
+	const char *param;
+	const char *sep = "";
+
+	postdata = g_string_new("{");
+	while ((param = va_arg(qargs, const char*))) {
+		const char *val = va_arg(qargs, const char*);
+		GString *escaped = slack_api_escape_quotes(val);
+		g_string_append_printf(postdata, "%s\"%s\":\"%s\"", sep, param, escaped->str);
+		g_string_free(escaped, TRUE);
+		sep = ",";
+	}
+
+	g_string_append_c(postdata, '}');
+
+	GString *request;
+	gchar *host = NULL, *path = NULL, *user = NULL, *password = NULL;
+	int port;
+	purple_url_parse(url->str, &host, &port, &path, &user, &password);
+
+	request = g_string_new(NULL);
+
+	g_string_append_printf(request, "POST /%s HTTP/1.0\r\n", path);
+	g_string_append(request, "Connection: close\r\n");
+	g_string_append_printf(request, "Host: %s\r\n", host);
+	g_string_append(request, "Accept: */*\r\n");
+	g_string_append_printf(request, "Authorization: Bearer %s\r\n", sa->token);
+	g_string_append(request, "Content-Type: application/json\r\n");
+
+	g_string_append_printf(request, "Content-Length: %" G_GSIZE_FORMAT "\r\n", strlen(postdata->str));
+	g_string_append(request, "\r\n");
+
+	g_string_append(request, postdata->str);
+
+	g_free(host);
+	g_free(path);
+	g_free(user);
+	g_free(password);
+	g_string_free(postdata, TRUE);
+
+	SlackUrlAndRequest ret = {url, request};
+	return ret;
+}
+
+static void slack_api_call_url(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, const char *url, const char *request) {
 	SlackAPICall *call = g_new0(SlackAPICall, 1);
 	call->sa = sa;
 	call->callback = callback;
 	call->url = g_strdup(url);
+	if (request)
+		call->request = g_strdup(request);
+	else
+		call->request = NULL;
 	call->data = user_data;
 	if ((call->next = sa->api_calls))
 		call->next->prev = &call->next;
 	call->prev = &sa->api_calls;
 	sa->api_calls = call;
 
-	purple_debug_misc("slack", "api call: %s\n", url);
+	purple_debug_misc("slack", "api call: %s\nRequest: %s\n", url, request ?: "Default");
 	api_retry(call);
 }
 
-void slack_api_call(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, const char *method, ...)
+void slack_api_get(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, const char *endpoint, ...)
 {
 	va_list qargs;
-	va_start(qargs, method);
-	GString *url = slack_api_encode_url(sa, "", method, qargs);
+	va_start(qargs, endpoint);
+	GString *url = slack_api_encode_url(sa, "", endpoint, qargs);
 	va_end(qargs);
 
-	slack_api_call_url(sa, callback, user_data, url->str);
+	slack_api_call_url(sa, callback, user_data, url->str, NULL);
+
 	g_string_free(url, TRUE);
 }
 
-gboolean slack_api_channel_call(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, SlackObject *obj, const char *method, ...) {
+void slack_api_post(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, const gchar *endpoint, ...)
+{
+	va_list qargs;
+	va_start(qargs, endpoint);
+	SlackUrlAndRequest url_and_request = slack_api_encode_url_and_post_request(sa, endpoint, qargs);
+	va_end(qargs);
+
+	slack_api_call_url(sa, callback, user_data, url_and_request.url->str, url_and_request.request->str);
+
+	g_string_free(url_and_request.url, TRUE);
+	g_string_free(url_and_request.request, TRUE);
+}
+
+gboolean slack_api_channel_get(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, SlackObject *obj, const char *endpoint, ...) {
 	g_return_val_if_fail(obj, FALSE);
 	const char *type = NULL, *id = NULL;
 	if (SLACK_IS_CHANNEL(obj)) {
@@ -154,12 +246,12 @@ gboolean slack_api_channel_call(SlackAccount *sa, SlackAPICallback callback, gpo
 		return FALSE;
 
 	va_list qargs;
-	va_start(qargs, method);
-	GString *url = slack_api_encode_url(sa, type, method, qargs);
+	va_start(qargs, endpoint);
+	GString *url = slack_api_encode_url(sa, type, endpoint, qargs);
 	va_end(qargs);
 	g_string_append_printf(url, "&channel=%s", purple_url_encode(id));
 
-	slack_api_call_url(sa, callback, user_data, url->str);
+	slack_api_call_url(sa, callback, user_data, url->str, NULL);
 	g_string_free(url, TRUE);
 	return TRUE;
 }

--- a/slack-api.h
+++ b/slack-api.h
@@ -10,8 +10,9 @@ PurpleConnectionError slack_api_connection_error(const gchar *error);
 typedef struct _SlackAPICall SlackAPICall;
 typedef gboolean SlackAPICallback(SlackAccount *sa, gpointer user_data, json_value *json, const char *error);
 
-void slack_api_call(SlackAccount *sa, SlackAPICallback *callback, gpointer user_data, const char *method, /* const char *query_param1, const char *query_value1, */ ...) G_GNUC_NULL_TERMINATED;
-gboolean slack_api_channel_call(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, SlackObject *obj, const char *method, ...) G_GNUC_NULL_TERMINATED;
+void slack_api_get(SlackAccount *sa, SlackAPICallback *callback, gpointer user_data, const char *endpoint, /* const char *query_param1, const char *query_value1, */ ...) G_GNUC_NULL_TERMINATED;
+void slack_api_post(SlackAccount *sa, SlackAPICallback *callback, gpointer user_data, const char *endpoint, /* const char *query_param1, const char *query_value1, */ ...) G_GNUC_NULL_TERMINATED;
+gboolean slack_api_channel_get(SlackAccount *sa, SlackAPICallback callback, gpointer user_data, SlackObject *obj, const char *endpoint, ...) G_GNUC_NULL_TERMINATED;
 void slack_api_disconnect(SlackAccount *sa);
 
 #define SLACK_PAGINATE_LIMIT	"limit", "100"

--- a/slack-auth.c
+++ b/slack-auth.c
@@ -49,7 +49,7 @@ slack_auth_login_finduser_cb(SlackAccount *sa, gpointer user_data, json_value *j
 
 	/* now do the actual login */
 	slack_login_step(sa);
-	slack_api_call(sa, slack_auth_login_signin_cb,
+	slack_api_get(sa, slack_auth_login_signin_cb,
 		NULL, "auth.signin",
 		"user", user_id,
 		"password", purple_account_get_password(sa->account),
@@ -75,7 +75,7 @@ slack_auth_login_findteam_cb(SlackAccount *sa, gpointer user_data, json_value *j
 
 	/* now validate that the user exists and get their ID. */
 	slack_login_step(sa);
-	slack_api_call(sa, slack_auth_login_finduser_cb,
+	slack_api_get(sa, slack_auth_login_finduser_cb,
 		NULL, "auth.findUser",
 		"email", sa->email,
 		"team", sa->team.id,
@@ -86,7 +86,7 @@ slack_auth_login_findteam_cb(SlackAccount *sa, gpointer user_data, json_value *j
 void
 slack_auth_login(SlackAccount *sa) {
 	/* validate the team and get it's ID */
-	slack_api_call(sa, slack_auth_login_findteam_cb,
+	slack_api_get(sa, slack_auth_login_findteam_cb,
 		NULL, "auth.findTeam",
 		"domain", sa->host,
 		NULL);

--- a/slack-blist.c
+++ b/slack-blist.c
@@ -140,7 +140,7 @@ struct roomlist_expand {
 };
 
 #define ROOMLIST_CALL(sa, expand, ARGS...) \
-	slack_api_call(sa, roomlist_cb, expand, "conversations.list", "exclude_archived", expand->parent ? "false" : "true", "type", "public_channel,private_channel,mpim,im", SLACK_PAGINATE_LIMIT, ##ARGS, NULL)
+	slack_api_get(sa, roomlist_cb, expand, "conversations.list", "exclude_archived", expand->parent ? "false" : "true", "type", "public_channel,private_channel,mpim,im", SLACK_PAGINATE_LIMIT, ##ARGS, NULL)
 
 static gboolean roomlist_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
 	struct roomlist_expand *expand = data;

--- a/slack-channel.c
+++ b/slack-channel.c
@@ -202,7 +202,7 @@ void slack_chat_open(SlackAccount *sa, SlackChannel *chan) {
 
 	serv_got_joined_chat(sa->gc, chan->cid, chan->object.name);
 
-	slack_api_call(sa, channels_info_cb, GINT_TO_POINTER(chan->type), chan->type >= SLACK_CHANNEL_GROUP ? "groups.info" : "channels.info", "channel", chan->object.id, NULL);
+	slack_api_get(sa, channels_info_cb, GINT_TO_POINTER(chan->type), chan->type >= SLACK_CHANNEL_GROUP ? "groups.info" : "channels.info", "channel", chan->object.id, NULL);
 }
 
 static gboolean channels_join_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
@@ -246,7 +246,7 @@ void slack_join_chat(PurpleConnection *gc, GHashTable *info) {
 	if (chan && chan->type >= SLACK_CHANNEL_MEMBER)
 		channels_join_cb(sa, join, NULL, NULL);
 	else
-		slack_api_call(sa, channels_join_cb, join, "channels.join", "name", name, NULL);
+		slack_api_post(sa, channels_join_cb, join, "channels.join", "name", name, NULL);
 }
 
 void slack_chat_leave(PurpleConnection *gc, int cid) {
@@ -355,7 +355,7 @@ void slack_chat_invite(PurpleConnection *gc, int cid, const char *message, const
 	if (!user)
 		return;
 
-	slack_api_call(sa, NULL, NULL, "conversations.invite", "channel", chan->object.id, "user", user->object.id, NULL);
+	slack_api_post(sa, NULL, NULL, "conversations.invite", "channel", chan->object.id, "user", user->object.id, NULL);
 }
 
 void slack_set_chat_topic(PurpleConnection *gc, int cid, const char *topic) {
@@ -365,5 +365,5 @@ void slack_set_chat_topic(PurpleConnection *gc, int cid, const char *topic) {
 	if (!chan)
 		return;
 
-	slack_api_call(sa, NULL, NULL, "conversations.setTopic", "channel", chan->object.id, "topic", topic, NULL);
+	slack_api_post(sa, NULL, NULL, "conversations.setTopic", "channel", chan->object.id, "topic", topic, NULL);
 }

--- a/slack-cmd.c
+++ b/slack-cmd.c
@@ -76,7 +76,7 @@ static PurpleCmdRet send_cmd(PurpleConversation *conv, const gchar *cmd, gchar *
 	g_string_append(msg, cmd);
 
 	/* https://github.com/ErikKalkoken/slackApiDoc/blob/master/chat.command.md */
-	slack_api_call(sa, send_cmd_cb, conv, "chat.command", "channel", slack_conversation_id(obj), "command", msg->str, "text", args && args[0] ? args[0] : "", NULL);
+	slack_api_post(sa, send_cmd_cb, conv, "chat.command", "channel", slack_conversation_id(obj), "command", msg->str, "text", args && args[0] ? args[0] : "", NULL);
 	g_string_free(msg, TRUE);
 
 	return PURPLE_CMD_RET_OK;
@@ -93,7 +93,7 @@ static PurpleCmdRet cmd_edit(PurpleConversation *conv, const gchar *cmd, gchar *
 		return PURPLE_CMD_RET_FAILED;
 	}
 
-	slack_api_call(sa, NULL, NULL, "chat.update", "channel", slack_conversation_id(obj), "ts", obj->last_sent, "as_user", "true", "text", args && args[0] ? args[0] : "", NULL);
+	slack_api_post(sa, NULL, NULL, "chat.update", "channel", slack_conversation_id(obj), "ts", obj->last_sent, "as_user", "true", "text", args && args[0] ? args[0] : "", NULL);
 	return PURPLE_CMD_RET_OK;
 }
 
@@ -108,7 +108,7 @@ static PurpleCmdRet cmd_delete(PurpleConversation *conv, const gchar *cmd, gchar
 		return PURPLE_CMD_RET_FAILED;
 	}
 
-	slack_api_call(sa, NULL, NULL, "chat.delete", "channel", slack_conversation_id(obj), "ts", obj->last_sent, "as_user", "true", NULL);
+	slack_api_post(sa, NULL, NULL, "chat.delete", "channel", slack_conversation_id(obj), "ts", obj->last_sent, "as_user", "true", NULL);
 	return PURPLE_CMD_RET_OK;
 }
 

--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -15,7 +15,7 @@ static SlackObject *conversation_update(SlackAccount *sa, json_value *json) {
 }
 
 #define CONVERSATIONS_LIST_CALL(sa, ARGS...) \
-	slack_api_call(sa, conversations_list_cb, NULL, "conversations.list", "types", "public_channel,private_channel,mpim,im", "exclude_archived", "true", SLACK_PAGINATE_LIMIT, ##ARGS, NULL)
+	slack_api_get(sa, conversations_list_cb, NULL, "conversations.list", "types", "public_channel,private_channel,mpim,im", "exclude_archived", "true", SLACK_PAGINATE_LIMIT, ##ARGS, NULL)
 
 static gboolean conversations_list_cb(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
 	json_value *chans = json_get_prop_type(json, "channels", array);
@@ -96,7 +96,7 @@ void slack_conversation_retrieve(SlackAccount *sa, const char *sid, SlackConvers
 	struct conversation_retrieve *lookup = g_new(struct conversation_retrieve, 1);
 	lookup->cb = cb;
 	lookup->data = data;
-	slack_api_call(sa, conversation_retrieve_cb, lookup, "conversations.info", "channel", sid, NULL);
+	slack_api_get(sa, conversation_retrieve_cb, lookup, "conversations.info", "channel", sid, NULL);
 }
 
 static gboolean mark_conversation_timer(gpointer data) {
@@ -113,7 +113,7 @@ static gboolean mark_conversation_timer(gpointer data) {
 		g_free(obj->last_mark);
 		obj->last_mark = g_strdup(obj->last_read);
 		/* XXX conversations.mark call??? */
-		slack_api_channel_call(sa, NULL, NULL, obj, "mark", "ts", obj->last_mark, NULL);
+		slack_api_channel_get(sa, NULL, NULL, obj, "mark", "ts", obj->last_mark, NULL);
 	}
 
 	return FALSE;
@@ -185,7 +185,7 @@ void slack_get_history(SlackAccount *sa, SlackObject *conv, const char *since, u
 
 	char count_buf[6] = "";
 	snprintf(count_buf, 5, "%u", count);
-	slack_api_call(sa, get_history_cb, g_object_ref(conv), "conversations.history", "channel", id, "oldest", since ?: "0", "limit", count_buf, NULL);
+	slack_api_get(sa, get_history_cb, g_object_ref(conv), "conversations.history", "channel", id, "oldest", since ?: "0", "limit", count_buf, NULL);
 }
 
 void slack_get_history_unread(SlackAccount *sa, SlackObject *conv, json_value *json) {
@@ -212,5 +212,5 @@ static gboolean get_conversation_unread_cb(SlackAccount *sa, gpointer data, json
 void slack_get_conversation_unread(SlackAccount *sa, SlackObject *conv) {
 	const char *id = slack_conversation_id(conv);
 	g_return_if_fail(id);
-	slack_api_call(sa, get_conversation_unread_cb, g_object_ref(conv), "conversations.info", "channel", id, NULL);
+	slack_api_get(sa, get_conversation_unread_cb, g_object_ref(conv), "conversations.info", "channel", id, NULL);
 }

--- a/slack-im.c
+++ b/slack-im.c
@@ -170,7 +170,7 @@ int slack_send_im(PurpleConnection *gc, const char *who, const char *msg, Purple
 	send->flags = flags;
 
 	if (!*user->im)
-		slack_api_call(sa, send_im_open_cb, send, "im.open", "user", user->object.id, "return_im", "true", NULL);
+		slack_api_post(sa, send_im_open_cb, send, "im.open", "user", user->object.id, "return_im", "true", NULL);
 	else
 		send_im_open_cb(sa, send, NULL, NULL);
 

--- a/slack-rtm.c
+++ b/slack-rtm.c
@@ -230,5 +230,5 @@ void slack_rtm_send(SlackAccount *sa, SlackRTMCallback *callback, gpointer user_
 }
 
 void slack_rtm_connect(SlackAccount *sa) {
-	slack_api_call(sa, rtm_connect_cb, NULL, "rtm.connect", "batch_presence_aware", "1", "presence_sub", "true", NULL);
+	slack_api_get(sa, rtm_connect_cb, NULL, "rtm.connect", "batch_presence_aware", "1", "presence_sub", "true", NULL);
 }

--- a/slack-user.c
+++ b/slack-user.c
@@ -111,7 +111,7 @@ static gboolean users_list_cb(SlackAccount *sa, gpointer data, json_value *json,
 
 	char *cursor = json_get_prop_strptr1(json_get_prop(json, "response_metadata"), "next_cursor");
 	if (cursor)
-		slack_api_call(sa, users_list_cb, NULL, "users.list", "presence", "false", SLACK_PAGINATE_LIMIT, "cursor", cursor, NULL);
+		slack_api_get(sa, users_list_cb, NULL, "users.list", "presence", "false", SLACK_PAGINATE_LIMIT, "cursor", cursor, NULL);
 	else
 		slack_login_step(sa);
 	return FALSE;
@@ -119,7 +119,7 @@ static gboolean users_list_cb(SlackAccount *sa, gpointer data, json_value *json,
 
 void slack_users_load(SlackAccount *sa) {
 	g_hash_table_remove_all(sa->users);
-	slack_api_call(sa, users_list_cb, NULL, "users.list", "presence", "false", SLACK_PAGINATE_LIMIT, NULL);
+	slack_api_get(sa, users_list_cb, NULL, "users.list", "presence", "false", SLACK_PAGINATE_LIMIT, NULL);
 }
 
 struct user_retrieve {
@@ -147,7 +147,7 @@ void slack_user_retrieve(SlackAccount *sa, const char *uid, SlackUserCallback *c
 	struct user_retrieve *lookup = g_new(struct user_retrieve, 1);
 	lookup->cb = cb;
 	lookup->data = data;
-	slack_api_call(sa, user_retrieve_cb, lookup, "users.info", "user", uid, NULL);
+	slack_api_get(sa, user_retrieve_cb, lookup, "users.info", "user", uid, NULL);
 }
 
 static void presence_set(SlackAccount *sa, json_value *json, const char *presence) {
@@ -254,7 +254,7 @@ static gboolean users_info_cb(SlackAccount *sa, gpointer data, json_value *json,
 
 void slack_set_info(PurpleConnection *gc, const char *info) {
 	SlackAccount *sa = gc->proto_data;
-	slack_api_call(sa, NULL, NULL, "users.profile.set", "name", "status_text", "value", info, NULL);
+	slack_api_post(sa, NULL, NULL, "users.profile.set", "name", "status_text", "value", info, NULL);
 }
 
 void slack_get_info(PurpleConnection *gc, const char *who) {
@@ -263,7 +263,7 @@ void slack_get_info(PurpleConnection *gc, const char *who) {
 	if (!user)
 		users_info_cb(sa, g_strdup(who), NULL, NULL);
 	else
-		slack_api_call(sa, users_info_cb, g_strdup(who), "users.info", "user", user->object.id, NULL);
+		slack_api_get(sa, users_info_cb, g_strdup(who), "users.info", "user", user->object.id, NULL);
 }
 
 static void avatar_load_next(SlackAccount *sa);

--- a/slack.c
+++ b/slack.c
@@ -54,7 +54,7 @@ static GList *slack_status_types(G_GNUC_UNUSED PurpleAccount *acct) {
 
 static gboolean slack_set_profile(SlackAccount *sa, gpointer data, json_value *json, const char *error) {
 	GString *profile_json = data;
-	slack_api_call(sa, NULL, NULL, "users.profile.set", "profile", profile_json->str, NULL);
+	slack_api_post(sa, NULL, NULL, "users.profile.set", "profile", profile_json->str, NULL);
 	g_string_free(profile_json, TRUE);
 	return FALSE;
 }
@@ -79,7 +79,7 @@ static void slack_set_status(PurpleAccount *account, PurpleStatus *status) {
 		g_string_append(profile_json, "\"\"");
 	g_string_append(profile_json, ",\"status_emoji\":\"\"}");
 
-	slack_api_call(sa, slack_set_profile, profile_json, "users.setPresence", "presence", sa->away ? "away" : "auto", NULL);
+	slack_api_post(sa, slack_set_profile, profile_json, "users.setPresence", "presence", sa->away ? "away" : "auto", NULL);
 }
 
 static void slack_set_idle(PurpleConnection *gc, int idle) {


### PR DESCRIPTION
The problem manifests when you are trying to edit a long message. The
partial URL mode causes the request, and therefore the message, to be
truncated. A message with a 100 characters is more than enough to
trigger it.

Therefore switch to POST so we can include the long parameters in the
body instead. We take the opportunity to switch all appropriate
endpoints over to POST, which is a more correct way to use the API in
general.

It's a bit hairy to do POST requests since Purple does not support
them natively, but we just need to construct a small set of headers.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>