### PR TITLE
Update channels and im to use converstations api

### DIFF
--- a/slack-im.c
+++ b/slack-im.c
@@ -170,7 +170,7 @@ int slack_send_im(PurpleConnection *gc, const char *who, const char *msg, Purple
 	send->flags = flags;
 
 	if (!*user->im)
-		slack_api_post(sa, send_im_open_cb, send, "im.open", "user", user->object.id, "return_im", "true", NULL);
+		slack_api_post(sa, send_im_open_cb, send, "converstations.open", "user", user->object.id, "return_im", "true", NULL);
 	else
 		send_im_open_cb(sa, send, NULL, NULL);
 


### PR DESCRIPTION
Per the Slack deprecation notice, all of the channels.*, groups.*, im.*
and mpim.* functions have been deprecated. As of February 24, 2021 these
old APIs have started to die off.

This fixes the fact that member listings one rooms after retirement of
these old APIs.

Fixes: #133
Fixes: #86
Partial for: #59 (local team members are
listed, just not external team members)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>