### PR TITLE
Fix incorrect macro expansion, leading to API error.

### DIFF
--- a/slack-api.h
+++ b/slack-api.h
@@ -14,7 +14,8 @@ void slack_api_get(SlackAccount *sa, SlackAPICallback *callback, gpointer user_d
 void slack_api_post(SlackAccount *sa, SlackAPICallback *callback, gpointer user_data, const char *endpoint, /* const char *query_param1, const char *query_value1, */ ...) G_GNUC_NULL_TERMINATED;
 void slack_api_disconnect(SlackAccount *sa);
 
-#define SLACK_LIMIT_ARG(COUNT)		"limit", #COUNT
+#define SLACK_LIMIT_ARG2(COUNT)		"limit", #COUNT
+#define SLACK_LIMIT_ARG(COUNT)		SLACK_LIMIT_ARG2(COUNT)
 
 #define SLACK_PAGINATE_LIMIT_COUNT	500
 #define SLACK_PAGINATE_LIMIT_ARG	SLACK_LIMIT_ARG(SLACK_PAGINATE_LIMIT_COUNT)


### PR DESCRIPTION
According to this page [1] you need a two level macro to expand a
macro argument that you're also going to stringize.

[1] https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>