### PR TITLE
FIX: typos and arguments in some Slack apis.

### DIFF
--- a/slack-channel.c
+++ b/slack-channel.c
@@ -269,7 +269,7 @@ void slack_join_chat(PurpleConnection *gc, GHashTable *info) {
 	if (chan && chan->type >= SLACK_CHANNEL_MEMBER)
 		channels_join_cb(sa, join, NULL, NULL);
 	else
-		slack_api_post(sa, channels_join_cb, join, "converstations.join", "name", name, NULL);
+		slack_api_post(sa, channels_join_cb, join, "conversations.join", "channel", chan->object.id, NULL);
 }
 
 void slack_chat_leave(PurpleConnection *gc, int cid) {

--- a/slack-im.c
+++ b/slack-im.c
@@ -184,7 +184,7 @@ int slack_im_send(SlackAccount *sa, SlackUser *user, const char *msg, PurpleMess
 	send->thread = g_strdup(thread);
 
 	if (!*user->im)
-		slack_api_post(sa, send_im_open_cb, send, "converstations.open", "user", user->object.id, "return_im", "true", NULL);
+		slack_api_post(sa, send_im_open_cb, send, "conversations.open", "users", user->object.id, "return_im", "true", NULL);
 	else
 		send_im_open_cb(sa, send, NULL, NULL);
 


### PR DESCRIPTION
The change brings two Slack API calls to match the documented interface on Slack's website.

I have changes to slack_join_chat(),
as I was unable to join a Slack channel, but with the changes I have succeded.

I haven't tested the change to slack_im_send(), as I don't know which user action invokes it.  I've just searched for the same misspelling of "conversations", and corrected typos.