### PR TITLE
Fix command registering and API calling

### DIFF
--- a/slack-api.c
+++ b/slack-api.c
@@ -94,7 +94,7 @@ static gboolean api_retry(SlackAPICall *call) {
 	purple_debug_misc("slack", "api call: %s\n%s\n", call->url, call->request ?: "");
 	PurpleUtilFetchUrlData *fetch =
 		purple_util_fetch_url_request_len_with_account(call->sa->account,
-			call->url, FALSE, NULL, TRUE, call->request, FALSE, 4096*1024,
+			call->url, TRUE, NULL, TRUE, call->request, FALSE, 4096*1024,
 			api_cb, call->sa);
 	if (fetch)
 		call->fetch = fetch;

--- a/slack-cmd.c
+++ b/slack-cmd.c
@@ -174,7 +174,6 @@ void slack_cmd_register() {
 		id = purple_cmd_register(cmdbuf, "s", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_PRPL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 				SLACK_PLUGIN_ID, send_cmd, cmd, NULL);
 		commands = g_slist_prepend(commands, GUINT_TO_POINTER(id));
-		cmdp++;
 	}
 
 	id = purple_cmd_register("history", "w", PURPLE_CMD_P_PRPL, PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY,


### PR DESCRIPTION
* Fix bug in slack-api.c, which change allowed the avatars to load and prevented slack from re-using the same cursor over and over in Slack API calls (See #149)
* Fix bug in slack-cmd.c, which increments `cmdp` twice every loop, skipping half the commands that the plugin intended to register
Hope this helps :)