### PR TITLE
Display old/new message in edits in opposite order and make them gray.

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -436,13 +436,14 @@ void slack_handle_message(SlackAccount *sa, SlackObject *obj, json_value *json, 
 		json_value *old_message = json_get_prop(json, "previous_message");
 		/* this may consist only of added attachments, no changed text */
 		gboolean changed = g_strcmp0(json_get_prop_strptr(message, "text"), json_get_prop_strptr(old_message, "text"));
-		g_string_append(html, "<font color=\"#717274\"><i>[edit]</i></font> ");
-		slack_json_to_html(html, sa, message, &flags);
+		g_string_append(html, "<font color=\"#717274\"><i>[edit] ");
 		if (old_message && changed) {
-			g_string_append(html, "<br>(Old message: ");
+			g_string_append(html, "(Old message: ");
 			slack_json_to_html(html, sa, old_message, NULL);
-			g_string_append(html, ")");
+			g_string_append(html, ")<br>");
 		}
+		g_string_append(html, "</i></font>");
+		slack_json_to_html(html, sa, message, &flags);
 	}
 	else if (!g_strcmp0(subtype, "message_deleted")) {
 		message = json_get_prop(json, "previous_message");


### PR DESCRIPTION
This matches better the reading order (most recent text last), and
makes it clearer which text is now most relevant.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>