### PR TITLE
Display parent message when /getthread is used

### DIFF
--- a/slack-conversation.c
+++ b/slack-conversation.c
@@ -244,7 +244,7 @@ static gboolean get_history_cb(SlackAccount *sa, gpointer data, json_value *json
 			const char *ts = json_get_prop_strptr(msg, "ts");
 			const char *thread_ts = json_get_prop_strptr(msg, "thread_ts");
 			if (thread_ts && !slack_ts_cmp(ts, thread_ts)) {
-				if (h->thread)
+				if (h->thread && !h->force_threads)
 					// When we are fetching threads, don't display
 					// the parent message, because it has already
 					// been displayed when fetching the non-thread


### PR DESCRIPTION
This change displays the parent message of the thread when the `/getthread`
command is used, because the parent message often has context that
the thread participants assume you can already see. I almost always want
to see the parent message when I run `/getthread`, and when I can't see
it, I find my self running `/history 10`, then `/history 100`, etc.
until I can see the parent message and match it back to the thread
replies, which is annoying. This fixed it for me, and it hopefully also
useful for others :)