### PR TITLE
Fix github bot output

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -277,8 +277,13 @@ static void slack_attachment_to_html(GString *html, SlackAccount *sa, json_value
 	if (title) {
 		g_string_append(html, brtag->str);
 		g_string_append(html, "<b><i>");
-		link_html(html, title_link, title);
+		if (title_link) {
+			link_html(html, title_link, title);
+		} else {
+			slack_message_to_html(html, sa, title, NULL, attachment_prefix->str);
+		}
 		g_string_append(html, "</i></b>");
+
 	}
 
 	// main text


### PR DESCRIPTION
The GitHub bot posts messages about pull requests. Its `title` field has mark-up in it with a link like this: `<https://github.com/dylex/slack-libpurple/pull/145|# 145 Fix segmentation fault hazard.>`. Further, its `title_link` field is empty. This ends up not posting the title in the channel at all, which is the only place in the message which contains a link to the pull request. Very annoying.

This PR is presented as a work-around. When no title_link is present, parse the title as if it has markdown in it.