### PR TITLE
Cache the last used thread ID for each channel.

### DIFF
--- a/slack-channel.c
+++ b/slack-channel.c
@@ -14,7 +14,9 @@
 G_DEFINE_TYPE(SlackChannel, slack_channel, SLACK_TYPE_OBJECT);
 
 static void slack_channel_finalize(GObject *gobj) {
-	// SlackChannel *chan = SLACK_CHANNEL(gobj);
+	SlackChannel *chan = SLACK_CHANNEL(gobj);
+	g_free(chan->cached_thread_ts.timestr);
+	g_free(chan->cached_thread_ts.thread_ts);
 
 	G_OBJECT_CLASS(slack_channel_parent_class)->finalize(gobj);
 }

--- a/slack-channel.h
+++ b/slack-channel.h
@@ -4,6 +4,7 @@
 #include "json.h"
 #include "slack-object.h"
 #include "slack.h"
+#include "slack-thread.h"
 
 typedef enum _SlackChannelType {
 	SLACK_CHANNEL_UNKNOWN = -1, /* no (new) information about type */
@@ -17,6 +18,8 @@ typedef enum _SlackChannelType {
 /* SlackChannel can represent both channels and groups (private channels) */
 struct _SlackChannel {
 	SlackObject object;
+
+	SlackCachedThreadTs cached_thread_ts;
 
 	SlackChannelType type;
 	int cid; /* purple chat id, in channel_cids */

--- a/slack-thread.h
+++ b/slack-thread.h
@@ -3,6 +3,14 @@
 
 #include "slack.h"
 
+struct _SlackCachedThreadTs {
+	char *timestr;
+	char *thread_ts;
+};
+
+#define SLACK_TYPE_CACHED_THREAD_TS slack_cached_thread_ts_get_type()
+G_DECLARE_FINAL_TYPE(SlackCachedThreadTs, slack_cached_thread_ts, SLACK, CACHED_THREAD_RS, SlackObject)
+
 /**
  * Appends a formatted ts timestamp to str.
  *

--- a/slack-user.c
+++ b/slack-user.c
@@ -15,6 +15,8 @@ static void slack_user_finalize(GObject *gobj) {
 	g_free(user->status);
 	g_free(user->avatar_hash);
 	g_free(user->avatar_url);
+	g_free(user->cached_thread_ts.timestr);
+	g_free(user->cached_thread_ts.thread_ts);
 
 	G_OBJECT_CLASS(slack_user_parent_class)->finalize(gobj);
 }

--- a/slack-user.h
+++ b/slack-user.h
@@ -4,10 +4,13 @@
 #include "json.h"
 #include "slack-object.h"
 #include "slack.h"
+#include "slack-thread.h"
 
 /* SlackUser represents both a user object, and an optional im object */
 struct _SlackUser {
 	SlackObject object;
+
+	SlackCachedThreadTs cached_thread_ts;
 
 	char *status;
 	char *avatar_hash;


### PR DESCRIPTION
This saves one roundtrip for every reply, and is noticably faster.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>