### PR TITLE
Convert URL for incoming calls

### DIFF
--- a/slack-message.c
+++ b/slack-message.c
@@ -164,6 +164,18 @@ void slack_message_to_html(GString *html, SlackAccount *sa, gchar *s, PurpleMess
 		}
 		s = r+1;
 	}
+
+	if (strstr(html->str, "slack.com/call") != NULL) {
+		gchar *find = g_strconcat(sa->host, "/call", NULL);
+		gchar *replace = g_strconcat( "app.slack.com/free-willy/", sa->team.id, NULL);
+		gchar *newHtml = purple_strreplace(html->str, find, replace);
+
+		g_string_assign(html, newHtml);
+
+		g_free(find);
+		g_free(replace);
+		g_free(newHtml);
+	}
 }
 
 /*


### PR DESCRIPTION
Slack communicates legacy URLs for calls.
We convert the incoming legacy URL to the new expected URL.

That allows users to click on the URL and end up within the call instead
of an error page.

Relates: #166