### PR TITLE
fix "Get history" for aliased channels

### DIFF
--- a/slack-blist.c
+++ b/slack-blist.c
@@ -39,6 +39,11 @@ void slack_buddy_free(PurpleBuddy *b) {
 		? PURPLE_CHAT(n)->account \
 		: NULL)
 
+static const char *get_chat_name(PurpleChat *chat)
+{
+	return g_hash_table_lookup(purple_chat_get_components(chat), "name");
+}
+
 SlackObject *slack_blist_node_get_obj(PurpleBlistNode *buddy, SlackAccount **sap) {
 	*sap = get_slack_account(PURPLE_BLIST_ACCOUNT(buddy));
 	if (!*sap)
@@ -46,7 +51,7 @@ SlackObject *slack_blist_node_get_obj(PurpleBlistNode *buddy, SlackAccount **sap
 	if (PURPLE_BLIST_NODE_IS_BUDDY(buddy))
 		return g_hash_table_lookup((*sap)->user_names, purple_buddy_get_name(PURPLE_BUDDY(buddy)));
 	else if (PURPLE_BLIST_NODE_IS_CHAT(buddy))
-		return g_hash_table_lookup((*sap)->channel_names, purple_chat_get_name(PURPLE_CHAT(buddy)));
+		return g_hash_table_lookup((*sap)->channel_names, get_chat_name(PURPLE_CHAT(buddy)));
 	return NULL;
 }
 
@@ -108,7 +113,7 @@ static void get_history_cb(PurpleBlistNode *buddy, PurpleRequestFields *fields) 
 
 static void get_history_prompt(PurpleBlistNode *buddy) {
 	SlackAccount *sa = get_slack_account(PURPLE_BLIST_ACCOUNT(buddy));
-	const char *name = PURPLE_BLIST_NODE_NAME(buddy);
+	const char *name = PURPLE_BLIST_NODE_IS_BUDDY(buddy) ? PURPLE_BLIST_NODE_NAME(buddy) : get_chat_name(PURPLE_CHAT(buddy));
 	g_return_if_fail(sa && name);
 
 	PurpleRequestFields *fields = purple_request_fields_new();


### PR DESCRIPTION
If you alias a channel in pidgin, "Get history" returns nothing.  But it works again after re-aliasing back to the original channel name.  This is the case for regular channels and MPDM group chats, but not single-recipient DMs.

Turns out that for chats (channels & MPDM), `PURPLE_BLIST_NODE_NAME()` and `purple_chat_get_name()` actually return the _alias_ for the chat (the pidgin alias, that is), rather than the real chat name.

(Presumably this is because `PurpleBuddy` has `name` & `alias` members, but `PurpleChat` only has an `alias`.  The real chat name is under `components`.)

The result is, the channel alias is used to do the lookup against `channel_names`, which contains the real names.  This lookup fails if the alias is different than the real channel name.  (Or perhaps even succeeds for the wrong channel if aliased that way.)

Anyway, fix this by grabbing the real name for chats from `components` in the callback function.

Also go ahead and fix the `name` in `get_history_prompt` for chats, for a consistent display.  That is, so that `@user` and `#channel` both display the real (slack) names rather than (pidgin) aliases.