### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ else
 
 LIBNAME=libslack.so
 
-CC=gcc
 PLUGIN_DIR_PURPLE:=$(DESTDIR)$(shell pkg-config --variable=plugindir $(PURPLE_MOD))
 DATA_ROOT_DIR_PURPLE:=$(DESTDIR)$(shell pkg-config --variable=datarootdir $(PURPLE_MOD))
 PKGS=$(PURPLE_MOD) glib-2.0 gobject-2.0


### PR DESCRIPTION
Allow CC to be defined by the OS (cc, normally symlinked to gcc).

This is needed for operating systems like FreeBSD that do not have gcc installed and instead build with clang