### PR TITLE
slack-message: add option for dropping old messages

### DIFF
--- a/slack.c
+++ b/slack.c
@@ -576,6 +576,9 @@ static void init_plugin(G_GNUC_UNUSED PurplePlugin *plugin)
 		purple_account_option_bool_new("Retrieve unread thread history too (slow!)", "thread_history", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
+		purple_account_option_int_new("Hide edits/deletes of messages older than 'n' hours)", "ignore_old_message_hours", 0));
+
+	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,
 		purple_account_option_bool_new("Download user avatars", "enable_avatar_download", FALSE));
 
 	prpl_info.protocol_options = g_list_append(prpl_info.protocol_options,


### PR DESCRIPTION
Sometimes a user (or bot) edits or deletes a message that is quite old. It can be very confusing to see such messages inserted in the current timeline, even with the '[edit]' or 'Deleted message' prefix, because they are totally out of context.

This adds an account option that allows hiding of edits/deletes on messages that are older than a certain number of hours. The option defaults to 0, so users get the full stream unless opting out.

This feature was motivated by an incredibly annoying bot on my workspace, which deletes its own messages when they are 30 days old. IOW, we have a constant stream of irrelevant 'deleted message' messages inserted into channels, that are completely outdated and confusing to the current discussion.
