### PR TITLE
slack-api.h: Bump SLACK_PAGINATE_LIMIT_COUNT to 1000

### DIFF
--- a/slack-api.h
+++ b/slack-api.h
@@ -16,7 +16,7 @@ void slack_api_disconnect(SlackAccount *sa);
 
 #define SLACK_LIMIT_ARG(COUNT)		"limit", G_STRINGIFY(COUNT)
 
-#define SLACK_PAGINATE_LIMIT_COUNT	500
+#define SLACK_PAGINATE_LIMIT_COUNT	1000
 #define SLACK_PAGINATE_LIMIT_ARG	SLACK_LIMIT_ARG(SLACK_PAGINATE_LIMIT_COUNT)
 
 // Documented as maximum in API (2020-07-20).


### PR DESCRIPTION
Logging into a large workspace was close to impossible without this due to the process timing out each time.

While enabling lazy_load option prevented the timeout, the ad-hoc user ID lookup did not happen for some reason so this wasn't a viable solution for me. FWIW: I'm using this via bitlbee.